### PR TITLE
Add credibility metrics strip to homepage hero

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,24 @@
             <p class="eyebrow">GovTech-focused Django Developer | Workflow Automation Builder | LGU Systems Process Specialist</p>
             <h1>Building practical systems for government workflows, internal operations, and real-world citizen services.</h1>
             <p class="hero-lead">I design and ship process-aware software with clear operational impact for local government teams. Current focus: transforming municipal tracing and assistance workflows into reliable digital systems.</p>
+            <div class="credibility-strip" role="list" aria-label="Credibility metrics">
+              <div class="credibility-item" role="listitem">
+                <p class="credibility-value">18+ workflows mapped</p>
+                <p class="credibility-label">Across assistance, routing, and case-tracing operations</p>
+              </div>
+              <div class="credibility-item" role="listitem">
+                <p class="credibility-value">34 hours/month reduced</p>
+                <p class="credibility-label">Through repeatable automation and standardized templates</p>
+              </div>
+              <div class="credibility-item" role="listitem">
+                <p class="credibility-value">3 pilot modules delivered</p>
+                <p class="credibility-label">Focused on intake, status visibility, and documentation</p>
+              </div>
+              <div class="credibility-item" role="listitem">
+                <p class="credibility-value">Audit trail readiness: implemented</p>
+                <p class="credibility-label">Event logs and handover notes built into process flow</p>
+              </div>
+            </div>
             <div class="hero-actions">
               <a class="btn btn-accent" href="#projects">View Projects</a>
               <a class="btn btn-outline-light" href="tracepoint.html">Explore TracePoint</a>

--- a/portfolio-refresh.css
+++ b/portfolio-refresh.css
@@ -93,6 +93,37 @@ footer p {
   color: var(--text-muted);
 }
 
+.credibility-strip {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.85rem;
+  margin-top: 1.1rem;
+}
+
+.credibility-item {
+  height: 100%;
+  border: 1px solid var(--border);
+  border-radius: 0.85rem;
+  background: linear-gradient(180deg, rgba(26, 39, 64, 0.9) 0%, rgba(18, 29, 47, 0.9) 100%);
+  box-shadow: inset 0 0 0 1px var(--accent-soft);
+  padding: 0.85rem 0.95rem;
+}
+
+.credibility-value {
+  margin: 0;
+  color: var(--text-primary);
+  font-weight: 700;
+  line-height: 1.35;
+  font-size: 0.98rem;
+}
+
+.credibility-label {
+  margin: 0.35rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.83rem;
+  line-height: 1.45;
+}
+
 .hero-actions {
   display: flex;
   flex-wrap: wrap;
@@ -217,9 +248,19 @@ footer p {
   }
 }
 
+@media (min-width: 1200px) {
+  .credibility-strip {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+}
+
 @media (max-width: 767px) {
   .content-section {
     padding: 3.4rem 0;
+  }
+
+  .credibility-strip {
+    grid-template-columns: 1fr;
   }
 
   .hero-actions .btn {


### PR DESCRIPTION
### Motivation
- Provide concise, measurable credibility metrics under the hero lead to surface operational impact and social proof on the homepage.
- Make those statements visually consistent with the existing design system using current tokens for contrast and subtle borders.
- Ensure the new component is accessible and responsive so it reads clearly on mobile and preserves equal visual weight on larger screens.

### Description
- Inserted a four-item `credibility-strip` block in `#home` directly between `.hero-lead` and `.hero-actions` with concrete metrics for workflows, monthly hours saved, pilot modules delivered, and audit-trail readiness.
- Added semantic ARIA roles (`role="list"` / `role="listitem"`) and concise label/value elements for clarity and screen-reader friendliness.
- Introduced CSS classes `.credibility-strip`, `.credibility-item`, `.credibility-value`, and `.credibility-label` in `portfolio-refresh.css` using `--border` and `--accent-soft` for high-contrast bordered cards and subtle inset accent.
- Implemented responsive grid behavior with 4 equal columns on wide viewports (`min-width: 1200px`), 2 columns by default, and a single-column stack on small screens (`max-width: 767px`).

### Testing
- Ran `git diff --check` and confirmed there are no whitespace or patch-formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df94daeba48324b3d8bc09128ab5f2)