### PR TITLE
Add high-intent CTA tiers and structured contact inquiry prompt

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,9 +44,10 @@
             <p class="eyebrow">GovTech-focused Django Developer | Workflow Automation Builder | LGU Systems Process Specialist</p>
             <h1>Building practical systems for government workflows, internal operations, and real-world citizen services.</h1>
             <p class="hero-lead">I design and ship process-aware software with clear operational impact for local government teams. Current focus: transforming municipal tracing and assistance workflows into reliable digital systems.</p>
-            <div class="hero-actions">
-              <a class="btn btn-accent" href="#projects">View Projects</a>
-              <a class="btn btn-outline-light" href="tracepoint.html">Explore TracePoint</a>
+            <div class="hero-actions cta-group" aria-label="Primary calls to action">
+              <a class="btn cta-btn cta-primary" href="#contact">Book a Systems Consultation</a>
+              <a class="btn cta-btn cta-secondary" href="#projects">Request Portfolio Walkthrough</a>
+              <a class="cta-tertiary" href="assets/teppy.pdf" download>Download CV</a>
             </div>
           </div>
           <div class="col-lg-4">
@@ -174,6 +175,59 @@
     <div class="container">
       <h2>Contact</h2>
       <p>Let’s collaborate on practical government systems and internal process modernization.</p>
+
+      <div class="cta-group footer-cta-group" aria-label="Contact calls to action">
+        <a class="btn cta-btn cta-primary" href="mailto:cristinoagapitojr@gmail.com?subject=Systems%20Consultation%20Request">Book a Systems Consultation</a>
+        <a class="btn cta-btn cta-secondary" href="mailto:cristinoagapitojr@gmail.com?subject=Portfolio%20Walkthrough%20Request">Request Portfolio Walkthrough</a>
+        <a class="cta-tertiary" href="assets/teppy.pdf" download>Download CV</a>
+      </div>
+
+      <div class="contact-prompt" role="form" aria-label="Project inquiry prompt">
+        <h3>Project Inquiry Snapshot</h3>
+        <p>Share these details in your email so I can prepare a targeted response:</p>
+        <form class="inquiry-form" action="mailto:cristinoagapitojr@gmail.com" method="post" enctype="text/plain">
+          <div class="inquiry-grid">
+            <label>
+              Scope
+              <select name="Scope" required>
+                <option value="" selected disabled>Select scope</option>
+                <option>New build</option>
+                <option>Modernization / migration</option>
+                <option>Workflow automation enhancement</option>
+              </select>
+            </label>
+            <label>
+              Timeline
+              <select name="Timeline" required>
+                <option value="" selected disabled>Select timeline</option>
+                <option>2–4 weeks</option>
+                <option>1–2 months</option>
+                <option>3+ months</option>
+              </select>
+            </label>
+            <label>
+              Office type
+              <select name="Office Type" required>
+                <option value="" selected disabled>Select office type</option>
+                <option>Municipal / city office</option>
+                <option>Provincial office</option>
+                <option>Inter-office / multi-unit team</option>
+              </select>
+            </label>
+            <label>
+              Challenge area
+              <select name="Challenge Area" required>
+                <option value="" selected disabled>Select challenge area</option>
+                <option>Case tracking visibility</option>
+                <option>Routing and approvals</option>
+                <option>Reporting and audit logs</option>
+              </select>
+            </label>
+          </div>
+          <button class="btn cta-btn cta-secondary inquiry-submit" type="submit">Send Inquiry Details</button>
+        </form>
+      </div>
+
       <ul class="contact-list">
         <li><a href="https://github.com/tepong32" target="_blank" rel="noopener noreferrer"><i class="bi bi-github"></i> GitHub</a></li>
         <li><a href="mailto:cristinoagapitojr@gmail.com"><i class="bi bi-envelope"></i> cristinoagapitojr@gmail.com</a></li>

--- a/portfolio-refresh.css
+++ b/portfolio-refresh.css
@@ -94,10 +94,113 @@ footer p {
 }
 
 .hero-actions {
+  margin-top: 1.4rem;
+}
+
+
+.cta-group {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 0.8rem;
   margin-top: 1.4rem;
+}
+
+.cta-btn {
+  border-radius: 0.7rem;
+  font-weight: 700;
+  padding: 0.65rem 1.05rem;
+  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+}
+
+.cta-primary {
+  border: 1px solid transparent;
+  background: var(--accent);
+  color: #03111f;
+}
+
+.cta-primary:hover {
+  background: #67b8ff;
+  color: #03111f;
+  transform: translateY(-1px);
+}
+
+.cta-secondary {
+  border: 1px solid rgba(126, 189, 255, 0.65);
+  color: #d8ebff;
+  background: transparent;
+}
+
+.cta-secondary:hover {
+  border-color: #9ed0ff;
+  color: #f1f8ff;
+  background: rgba(62, 166, 255, 0.12);
+}
+
+.cta-tertiary {
+  color: #b9dfff;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  text-decoration-color: rgba(185, 223, 255, 0.55);
+  font-weight: 600;
+  padding: 0.35rem 0.2rem;
+}
+
+.cta-tertiary:hover {
+  color: #ffffff;
+  text-decoration-color: currentColor;
+}
+
+.cta-btn:focus-visible,
+.cta-tertiary:focus-visible,
+.inquiry-form select:focus-visible {
+  outline: 3px solid rgba(98, 188, 255, 0.62);
+  outline-offset: 2px;
+}
+
+.footer-cta-group {
+  margin-bottom: 1.2rem;
+}
+
+.contact-prompt {
+  border: 1px solid var(--border);
+  border-radius: 0.9rem;
+  padding: 1rem;
+  background: rgba(19, 31, 52, 0.76);
+  margin-bottom: 1.2rem;
+}
+
+.contact-prompt h3 {
+  margin-bottom: 0.45rem;
+  font-size: 1.08rem;
+}
+
+.inquiry-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem;
+  margin: 0.9rem 0;
+}
+
+.inquiry-form label {
+  display: grid;
+  gap: 0.38rem;
+  color: #d7e9ff;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.inquiry-form select {
+  width: 100%;
+  border-radius: 0.58rem;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  background: rgba(7, 12, 21, 0.92);
+  color: var(--text-primary);
+  padding: 0.55rem 0.65rem;
+}
+
+.inquiry-submit {
+  margin-top: 0.2rem;
 }
 
 .btn-accent {
@@ -222,7 +325,14 @@ footer p {
     padding: 3.4rem 0;
   }
 
-  .hero-actions .btn {
+  .cta-group .cta-btn,
+  .cta-group .cta-tertiary,
+  .inquiry-submit {
     width: 100%;
+    text-align: center;
+  }
+
+  .inquiry-grid {
+    grid-template-columns: 1fr;
   }
 }


### PR DESCRIPTION
### Motivation
- Provide clear, conversion-focused CTAs in the hero and footer to surface high-intent actions for prospective clients.
- Offer a compact, low-friction project inquiry prompt so visitors can quickly share key project context before an email or call.

### Description
- Replaced the hero action links with a three-tier CTA group containing `Book a Systems Consultation` (primary), `Request Portfolio Walkthrough` (secondary), and `Download CV` (tertiary) by updating `index.html` and adding the same CTA group to the footer `#contact` section.
- Added a compact inquiry form in `#contact` with structured fields for `Scope`, `Timeline`, `Office Type`, and `Challenge Area` and a submit action targeting the portfolio email address.
- Implemented new CSS in `portfolio-refresh.css` including `.cta-group`, `.cta-btn`, `.cta-primary`, `.cta-secondary`, and `.cta-tertiary` to provide a filled primary button, outlined secondary button, and subtle text tertiary CTA, plus form styling for the inquiry prompt.
- Added accessible focus-visible outlines, hover interaction states, and responsive rules so all CTA controls become full-width on small screens and the inquiry grid collapses to a single column.

### Testing
- Ran repository checks including `git diff --check` which reported no errors and `git status --short` to confirm tracked changes, both succeeded. 
- Confirmed responsive CSS rules by inspecting mobile breakpoint rules in `portfolio-refresh.css`, and verified focus/hover rules are present for the new CTA and form controls.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df94fefb0c8324aaea06afddab7a66)