### PR TITLE
Add TracePoint Live board (static page, GitHub sync JS, styles)

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
             <li class="nav-item"><a class="nav-link" href="#home">Home</a></li>
             <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
             <li class="nav-item"><a class="nav-link" href="#projects">Projects</a></li>
+            <li class="nav-item"><a class="nav-link" href="tracepoint-live.html">TracePoint Live</a></li>
             <li class="nav-item"><a class="nav-link" href="#journal">Engineering Journal</a></li>
             <li class="nav-item"><a class="nav-link" href="#cv">CV</a></li>
             <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
@@ -47,6 +48,7 @@
             <div class="hero-actions cta-group" aria-label="Primary calls to action">
               <a class="btn cta-btn cta-primary" href="#contact">Book a Systems Consultation</a>
               <a class="btn cta-btn cta-secondary" href="#projects">Request Portfolio Walkthrough</a>
+              <a class="cta-tertiary" href="tracepoint-live.html">TracePoint Live Board</a>
               <a class="cta-tertiary" href="assets/teppy.pdf" download>Download CV</a>
             </div>
           </div>
@@ -56,6 +58,7 @@
               <h2>Currently building TracePoint</h2>
               <p>A case-driven platform for LGU process tracking, citizen assistance visibility, and workflow accountability.</p>
               <span class="milestone-badge">Milestone: Core Workflow Foundation</span>
+              <a class="repo-live-link" href="tracepoint-live.html"><i class="bi bi-activity" aria-hidden="true"></i> View live development pulse</a>
             </aside>
           </div>
         </div>
@@ -178,7 +181,10 @@
             <p class="case-label">4. Outcome / expected operational impact</p>
             <p>Expected outcomes include faster case turnaround, clearer cross-office ownership, and stronger audit readiness for service delivery oversight.</p>
           </div>
-          <a class="btn btn-accent align-self-start" href="tracepoint.html">Open Project Brief</a>
+          <div class="feature-actions">
+            <a class="btn btn-accent align-self-start" href="tracepoint.html">Open Project Brief</a>
+            <a class="btn btn-outline-light align-self-start" href="tracepoint-live.html">View Live Repo Board</a>
+          </div>
         </article>
 
         <div class="row g-4 project-grid">
@@ -272,6 +278,7 @@
       <div class="cta-group footer-cta-group" aria-label="Contact calls to action">
         <a class="btn cta-btn cta-primary" href="mailto:cristinoagapitojr@gmail.com?subject=Systems%20Consultation%20Request">Book a Systems Consultation</a>
         <a class="btn cta-btn cta-secondary" href="mailto:cristinoagapitojr@gmail.com?subject=Portfolio%20Walkthrough%20Request">Request Portfolio Walkthrough</a>
+        <a class="cta-tertiary" href="tracepoint-live.html">TracePoint Live Board</a>
         <a class="cta-tertiary" href="assets/teppy.pdf" download>Download CV</a>
       </div>
 

--- a/js/tracepoint-live.js
+++ b/js/tracepoint-live.js
@@ -1,0 +1,196 @@
+(function () {
+  const repoConfig = {
+    owner: 'tepong32',
+    repo: 'tracepoint',
+    branch: 'main'
+  };
+
+  const apiBase = `https://api.github.com/repos/${repoConfig.owner}/${repoConfig.repo}`;
+  const repoUrl = `https://github.com/${repoConfig.owner}/${repoConfig.repo}`;
+  const fallbackPrs = [
+    {
+      number: 'local',
+      title: 'TracePoint activity sync is ready for public repository data',
+      state: 'warning',
+      html_url: repoUrl,
+      updated_at: new Date().toISOString(),
+      body: 'If GitHub rate limits the visitor or the repository is private, this board keeps the project story intact while pointing visitors to the source repository.',
+      user: { login: repoConfig.owner }
+    }
+  ];
+  const fallbackCommits = [
+    {
+      html_url: repoUrl,
+      sha: 'pending',
+      commit: {
+        message: 'Waiting for public GitHub commit activity',
+        author: {
+          name: repoConfig.owner,
+          date: new Date().toISOString()
+        }
+      }
+    }
+  ];
+
+  const elements = {
+    healthTitle: document.getElementById('repo-health-title'),
+    healthCopy: document.getElementById('repo-health-copy'),
+    branch: document.getElementById('repo-branch'),
+    lastTouch: document.getElementById('repo-last-touch'),
+    description: document.getElementById('repo-description'),
+    visibility: document.getElementById('repo-visibility'),
+    stars: document.getElementById('repo-stars'),
+    forks: document.getElementById('repo-forks'),
+    openIssues: document.getElementById('repo-open-issues'),
+    pushed: document.getElementById('repo-pushed'),
+    terminalOne: document.getElementById('terminal-line-one'),
+    terminalTwo: document.getElementById('terminal-line-two'),
+    prFeed: document.getElementById('pull-request-feed'),
+    commitStream: document.getElementById('commit-stream'),
+    refresh: document.getElementById('repo-refresh')
+  };
+
+  const formatter = new Intl.DateTimeFormat('en', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+
+  function escapeHtml(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function formatDate(value) {
+    if (!value) return 'Not available';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return 'Not available';
+    return formatter.format(date);
+  }
+
+  function summarize(text) {
+    if (!text) return 'No public PR body was provided, but the activity record still shows recent project movement.';
+    const cleaned = text
+      .replace(/```[\s\S]*?```/g, '')
+      .replace(/[#*_>`~-]/g, '')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 220);
+
+    return escapeHtml(cleaned || 'No public PR body was provided, but the activity record still shows recent project movement.');
+  }
+
+  function statusLabel(pr) {
+    if (pr.merged_at) return 'merged';
+    if (pr.state === 'open') return 'open';
+    if (pr.state === 'warning') return 'sync note';
+    return 'closed';
+  }
+
+  function renderRepo(repo) {
+    const pushedDate = formatDate(repo.pushed_at);
+    elements.healthTitle.textContent = 'TracePoint repository is actively inspectable';
+    elements.healthCopy.textContent = `Latest public repository touch detected on ${pushedDate}. Visitors can verify ongoing implementation from the source activity.`;
+    elements.branch.textContent = repo.default_branch || repoConfig.branch;
+    elements.lastTouch.textContent = pushedDate;
+    elements.description.textContent = repo.description || 'TracePoint is a lifecycle-driven GovTech assistance platform under active development.';
+    elements.visibility.textContent = repo.private ? 'Private repo' : 'Public repo';
+    elements.stars.textContent = repo.stargazers_count ?? '0';
+    elements.forks.textContent = repo.forks_count ?? '0';
+    elements.openIssues.textContent = repo.open_issues_count ?? '0';
+    elements.pushed.textContent = pushedDate;
+    elements.terminalOne.textContent = `repo: ${repo.full_name || `${repoConfig.owner}/${repoConfig.repo}`} · branch: ${repo.default_branch || repoConfig.branch}`;
+    elements.terminalTwo.textContent = `last-push: ${pushedDate} · visibility: ${repo.private ? 'private' : 'public'}`;
+  }
+
+  function renderPrs(prs) {
+    elements.prFeed.innerHTML = prs.map((pr) => `
+      <article class="repo-feed-item">
+        <div class="feed-item-topline">
+          <span class="pr-state pr-state-${statusLabel(pr).replace(' ', '-')}">${statusLabel(pr)}</span>
+          <time datetime="${escapeHtml(pr.updated_at || '')}">${formatDate(pr.updated_at)}</time>
+        </div>
+        <h3><a href="${escapeHtml(pr.html_url || repoUrl)}" target="_blank" rel="noopener noreferrer">#${escapeHtml(pr.number)} ${escapeHtml(pr.title)}</a></h3>
+        <p>${summarize(pr.body)}</p>
+        <span class="feed-author"><i class="bi bi-person-circle" aria-hidden="true"></i> touched by ${escapeHtml(pr.user?.login || repoConfig.owner)}</span>
+      </article>
+    `).join('');
+  }
+
+  function renderCommits(commits) {
+    elements.commitStream.innerHTML = commits.map((commit) => {
+      const message = commit.commit?.message?.split('\n')[0] || 'Implementation update';
+      const author = commit.commit?.author?.name || repoConfig.owner;
+      const date = commit.commit?.author?.date || '';
+      const sha = commit.sha ? commit.sha.slice(0, 7) : 'pending';
+      return `
+        <a class="commit-item" href="${escapeHtml(commit.html_url || repoUrl)}" target="_blank" rel="noopener noreferrer">
+          <span class="commit-node" aria-hidden="true"></span>
+          <span class="commit-copy">
+            <strong>${escapeHtml(message)}</strong>
+            <small>${escapeHtml(sha)} · ${escapeHtml(author)} · ${formatDate(date)}</small>
+          </span>
+        </a>
+      `;
+    }).join('');
+  }
+
+  function renderFallback(error) {
+    elements.healthTitle.textContent = 'GitHub sync fallback is active';
+    elements.healthCopy.textContent = 'The live board is ready, but public GitHub data could not be loaded right now. This can happen because of rate limits, a private repository, or a renamed repo.';
+    elements.lastTouch.textContent = 'Sync unavailable';
+    elements.pushed.textContent = 'Unavailable';
+    elements.terminalOne.textContent = 'sync: fallback-mode · reason: public-api-unavailable';
+    elements.terminalTwo.textContent = `next-step: confirm repo path ${repoConfig.owner}/${repoConfig.repo}`;
+    renderPrs(fallbackPrs);
+    renderCommits(fallbackCommits);
+    console.warn('TracePoint GitHub sync unavailable:', error);
+  }
+
+  async function fetchJson(url) {
+    const response = await fetch(url, {
+      headers: {
+        Accept: 'application/vnd.github+json'
+      }
+    });
+
+    if (!response.ok) {
+      throw new Error(`${response.status} ${response.statusText}`);
+    }
+
+    return response.json();
+  }
+
+  async function loadRepoBoard() {
+    elements.refresh?.setAttribute('disabled', 'disabled');
+    elements.refresh?.classList.add('is-loading');
+
+    try {
+      const [repo, prs, commits] = await Promise.all([
+        fetchJson(apiBase),
+        fetchJson(`${apiBase}/pulls?state=all&sort=updated&direction=desc&per_page=6`),
+        fetchJson(`${apiBase}/commits?per_page=7`)
+      ]);
+
+      renderRepo(repo);
+      renderPrs(prs.length ? prs : fallbackPrs);
+      renderCommits(commits.length ? commits : fallbackCommits);
+    } catch (error) {
+      renderFallback(error);
+    } finally {
+      elements.refresh?.removeAttribute('disabled');
+      elements.refresh?.classList.remove('is-loading');
+    }
+  }
+
+  document.querySelectorAll('[data-repo-link]').forEach((link) => {
+    link.href = repoUrl;
+  });
+
+  elements.refresh?.addEventListener('click', loadRepoBoard);
+  loadRepoBoard();
+})();

--- a/portfolio-refresh.css
+++ b/portfolio-refresh.css
@@ -601,3 +601,484 @@ footer p {
     grid-template-columns: 1fr;
   }
 }
+
+.repo-live-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin-top: var(--space-2);
+  color: #c6e6ff;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.repo-live-link:hover,
+.repo-live-link:focus {
+  color: #ffffff;
+  text-decoration: underline;
+  text-underline-offset: 0.22em;
+}
+
+.feature-actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 190px;
+}
+
+.repo-board-page {
+  background:
+    radial-gradient(circle at 18% 18%, rgba(62, 166, 255, 0.18), transparent 32rem),
+    radial-gradient(circle at 90% 10%, rgba(112, 220, 255, 0.12), transparent 28rem),
+    linear-gradient(180deg, #070d18 0%, #0b1220 48%, #06101d 100%);
+}
+
+.repo-hero {
+  padding: calc(var(--space-8) + var(--space-2)) 0 var(--space-5);
+}
+
+.repo-shell,
+.repo-panel,
+.repo-status-card {
+  border: 1px solid rgba(148, 190, 230, 0.22);
+  background: rgba(9, 16, 29, 0.86);
+  box-shadow: 0 24px 60px rgba(1, 8, 18, 0.38);
+}
+
+.repo-shell {
+  overflow: hidden;
+  border-radius: 1.25rem;
+}
+
+.repo-titlebar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(148, 190, 230, 0.2);
+  background: linear-gradient(90deg, rgba(17, 31, 56, 0.96), rgba(10, 19, 34, 0.96));
+}
+
+.repo-window-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+}
+
+.repo-window-controls span {
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: 50%;
+  background: #ff6b6b;
+}
+
+.repo-window-controls span:nth-child(2) {
+  background: #ffd166;
+}
+
+.repo-window-controls span:nth-child(3) {
+  background: #5ee6a8;
+}
+
+.repo-path,
+.repo-sync-pill {
+  margin: 0;
+  color: #cfe9ff;
+}
+
+.repo-path {
+  flex: 1;
+  font-family: var(--bs-font-monospace, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  font-size: 0.95rem;
+}
+
+.repo-sync-pill,
+.repo-chip,
+.pr-state {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  border-radius: 999px;
+  border: 1px solid rgba(126, 189, 255, 0.42);
+  background: rgba(62, 166, 255, 0.13);
+  color: #cfebff;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.repo-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.55fr) minmax(290px, 0.7fr);
+  gap: var(--space-4);
+  padding: var(--space-5);
+}
+
+.repo-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+
+.repo-status-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: 1rem;
+  padding: var(--space-3);
+}
+
+.repo-status-card::before {
+  content: "";
+  position: absolute;
+  inset: -40% -25% auto auto;
+  width: 16rem;
+  height: 16rem;
+  border-radius: 50%;
+  background: rgba(62, 166, 255, 0.18);
+  filter: blur(10px);
+}
+
+.status-orb {
+  position: relative;
+  width: 3.2rem;
+  height: 3.2rem;
+  border-radius: 50%;
+  margin-bottom: var(--space-2);
+  background: radial-gradient(circle, #9be7ff 0%, #3ea6ff 42%, rgba(62, 166, 255, 0.08) 72%);
+  box-shadow: 0 0 0 0 rgba(62, 166, 255, 0.45);
+  animation: pulse-orb 2.2s infinite;
+}
+
+@keyframes pulse-orb {
+  0% { box-shadow: 0 0 0 0 rgba(62, 166, 255, 0.38); }
+  70% { box-shadow: 0 0 0 1.1rem rgba(62, 166, 255, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(62, 166, 255, 0); }
+}
+
+.repo-mini-stats {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-2);
+  margin: var(--space-3) 0 0;
+}
+
+.repo-mini-stats div,
+.repo-stat-card {
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 0.85rem;
+  background: rgba(17, 31, 56, 0.72);
+  padding: 0.8rem;
+}
+
+.repo-mini-stats dt,
+.repo-stat-label {
+  color: var(--text-muted);
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+}
+
+.repo-mini-stats dd {
+  margin: 0.25rem 0 0;
+  color: var(--text-primary);
+  font-weight: 800;
+}
+
+.repo-dashboard-section {
+  padding-top: var(--space-6);
+}
+
+.repo-dashboard-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.75fr);
+  gap: var(--space-4);
+}
+
+.repo-panel {
+  position: relative;
+  z-index: 1;
+  border-radius: 1rem;
+  padding: var(--space-3);
+}
+
+.repo-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.repo-panel-header.compact {
+  margin-bottom: var(--space-2);
+}
+
+.repo-stat-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-2);
+  margin: var(--space-3) 0;
+}
+
+.repo-stat-value {
+  display: block;
+  color: #ffffff;
+  font-size: clamp(1.35rem, 2.6vw, 2rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+}
+
+.repo-stat-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.repo-terminal {
+  border: 1px solid rgba(94, 230, 168, 0.24);
+  border-radius: 0.95rem;
+  background: #050b12;
+  color: #9ef2c3;
+  font-family: var(--bs-font-monospace, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+  padding: 1rem;
+}
+
+.repo-terminal p {
+  margin: 0;
+  color: #9ef2c3;
+  font-size: 0.88rem;
+}
+
+.repo-terminal p + p {
+  margin-top: 0.45rem;
+}
+
+.repo-terminal span {
+  color: #55b8ff;
+}
+
+.repo-proof-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.repo-proof-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.7rem;
+  color: #dceeff;
+}
+
+.repo-proof-list i {
+  color: var(--accent);
+  margin-top: 0.15rem;
+}
+
+.repo-feed,
+.commit-stream {
+  display: grid;
+  gap: var(--space-2);
+}
+
+.repo-feed-item,
+.commit-item {
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.9rem;
+  background: rgba(17, 31, 56, 0.68);
+  padding: var(--space-2);
+}
+
+.repo-feed-item h3 {
+  font-size: 1.04rem;
+  margin: 0.7rem 0 0.55rem;
+}
+
+.repo-feed-item h3 a,
+.commit-item {
+  color: #f1f8ff;
+  text-decoration: none;
+}
+
+.repo-feed-item h3 a:hover,
+.commit-item:hover strong {
+  color: #8fd0ff;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.repo-feed-item p {
+  color: var(--text-muted);
+  margin-bottom: 0.75rem;
+}
+
+.feed-item-topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--text-muted);
+  font-size: 0.86rem;
+}
+
+.pr-state-merged {
+  border-color: rgba(161, 125, 255, 0.46);
+  background: rgba(126, 87, 255, 0.17);
+  color: #dacbff;
+}
+
+.pr-state-open {
+  border-color: rgba(94, 230, 168, 0.42);
+  background: rgba(94, 230, 168, 0.13);
+  color: #baf7d4;
+}
+
+.pr-state-closed,
+.pr-state-sync-note {
+  border-color: rgba(255, 209, 102, 0.42);
+  background: rgba(255, 209, 102, 0.13);
+  color: #ffe2a3;
+}
+
+.feed-author {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: #c8e4ff;
+  font-size: 0.86rem;
+  font-weight: 650;
+}
+
+.repo-refresh-btn {
+  border: 1px solid rgba(126, 189, 255, 0.45);
+  border-radius: 999px;
+  background: rgba(62, 166, 255, 0.12);
+  color: #d8efff;
+  font-weight: 800;
+  padding: 0.45rem 0.78rem;
+}
+
+.repo-refresh-btn:hover,
+.repo-refresh-btn:focus {
+  border-color: #9ed0ff;
+  background: rgba(62, 166, 255, 0.2);
+}
+
+.repo-refresh-btn.is-loading i {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.commit-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: start;
+}
+
+.commit-node {
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  background: #5ee6a8;
+  box-shadow: 0 0 0 0.35rem rgba(94, 230, 168, 0.1);
+  margin-top: 0.36rem;
+}
+
+.commit-copy strong,
+.commit-copy small {
+  display: block;
+}
+
+.commit-copy small {
+  color: var(--text-muted);
+  margin-top: 0.35rem;
+}
+
+.skeleton-card span {
+  display: block;
+  height: 0.8rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.08));
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+.skeleton-card span + span {
+  margin-top: 0.7rem;
+  width: 75%;
+}
+
+.skeleton-card span:nth-child(3) {
+  width: 48%;
+}
+
+@keyframes shimmer {
+  to { background-position: -200% 0; }
+}
+
+@media (max-width: 991px) {
+  .repo-hero-grid,
+  .repo-dashboard-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .repo-titlebar,
+  .repo-panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .repo-stat-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767px) {
+  .repo-hero {
+    padding-top: var(--space-6);
+  }
+
+  .repo-hero-grid,
+  .repo-shell .repo-titlebar {
+    padding: var(--space-3);
+  }
+
+  .repo-actions .btn,
+  .feature-actions .btn {
+    width: 100%;
+  }
+
+  .repo-mini-stats,
+  .repo-stat-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.tracepoint-nav-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+@media (max-width: 767px) {
+  .tracepoint-nav-actions {
+    width: 100%;
+    margin-top: var(--space-2);
+  }
+
+  .tracepoint-nav-actions .btn {
+    flex: 1 1 100%;
+  }
+}

--- a/tracepoint-live.html
+++ b/tracepoint-live.html
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>TracePoint Live Build Board | Cristino Agapito Jr</title>
+  <meta name="description" content="A GitHub-inspired live development board for TracePoint, highlighting repository activity, recent pull requests, and continuous build progress.">
+  <link rel="icon" type="image/x-icon" href="assets/img/smile.png">
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link href="portfolio-refresh.css" rel="stylesheet">
+</head>
+<body class="repo-board-page">
+  <header class="site-header sticky-top">
+    <nav class="navbar navbar-expand-lg" aria-label="Primary navigation">
+      <div class="container">
+        <a class="navbar-brand" href="index.html#home">
+          <img src="assets/img/smile.png" alt="Portfolio logo" width="30" height="30">
+          <span>Cristino Agapito Jr</span>
+        </a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#mainNav" aria-controls="mainNav" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="mainNav">
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item"><a class="nav-link" href="index.html#home">Home</a></li>
+            <li class="nav-item"><a class="nav-link" href="index.html#projects">Projects</a></li>
+            <li class="nav-item"><a class="nav-link active" aria-current="page" href="tracepoint-live.html">TracePoint Live</a></li>
+            <li class="nav-item"><a class="nav-link" href="tracepoint.html">Project Brief</a></li>
+            <li class="nav-item"><a class="nav-link" href="index.html#contact">Contact</a></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+  </header>
+
+  <main>
+    <section class="repo-hero">
+      <div class="container">
+        <div class="repo-shell">
+          <div class="repo-titlebar" aria-label="TracePoint repository display">
+            <div class="repo-window-controls" aria-hidden="true">
+              <span></span><span></span><span></span>
+            </div>
+            <p class="repo-path"><i class="bi bi-github" aria-hidden="true"></i> tepong32 / <strong>tracepoint</strong></p>
+            <span class="repo-sync-pill"><i class="bi bi-broadcast-pin" aria-hidden="true"></i> Live GitHub sync</span>
+          </div>
+
+          <div class="repo-hero-grid">
+            <div>
+              <p class="eyebrow">Flagship project development pulse</p>
+              <h1>TracePoint Live Build Board</h1>
+              <p class="hero-lead">A GitHub-inspired project room that reads public repository activity and turns the latest commits, pull requests, and repository signals into a transparent proof-of-work board.</p>
+              <div class="repo-actions">
+                <a class="btn btn-accent" data-repo-link href="https://github.com/tepong32/tracepoint" target="_blank" rel="noopener noreferrer">Open GitHub Repo</a>
+                <a class="btn btn-outline-light" href="tracepoint.html">Read Project Brief</a>
+              </div>
+            </div>
+
+            <aside class="repo-status-card" aria-label="Repository status summary">
+              <div class="status-orb" aria-hidden="true"></div>
+              <p class="badge-label">Continuous Development</p>
+              <h2 id="repo-health-title">Connecting to GitHub…</h2>
+              <p id="repo-health-copy">Fetching the latest public TracePoint activity, repository metadata, and pull request summaries.</p>
+              <dl class="repo-mini-stats">
+                <div>
+                  <dt>Branch</dt>
+                  <dd id="repo-branch">main</dd>
+                </div>
+                <div>
+                  <dt>Last touch</dt>
+                  <dd id="repo-last-touch">Loading…</dd>
+                </div>
+              </dl>
+            </aside>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section section--cases repo-dashboard-section">
+      <div class="container">
+        <div class="repo-dashboard-grid">
+          <section class="repo-panel repo-readme-card" aria-labelledby="repo-overview-title">
+            <div class="repo-panel-header">
+              <div>
+                <p class="project-tag">Repository overview</p>
+                <h2 id="repo-overview-title">TracePoint proof-of-work snapshot</h2>
+              </div>
+              <span class="repo-chip" id="repo-visibility">Public repo</span>
+            </div>
+            <p id="repo-description">TracePoint is a lifecycle-driven GovTech assistance platform under active development.</p>
+            <div class="repo-stat-grid" aria-label="GitHub repository statistics">
+              <div class="repo-stat-card">
+                <span class="repo-stat-value" id="repo-stars">—</span>
+                <span class="repo-stat-label"><i class="bi bi-star" aria-hidden="true"></i> Stars</span>
+              </div>
+              <div class="repo-stat-card">
+                <span class="repo-stat-value" id="repo-forks">—</span>
+                <span class="repo-stat-label"><i class="bi bi-diagram-2" aria-hidden="true"></i> Forks</span>
+              </div>
+              <div class="repo-stat-card">
+                <span class="repo-stat-value" id="repo-open-issues">—</span>
+                <span class="repo-stat-label"><i class="bi bi-record-circle" aria-hidden="true"></i> Open issues</span>
+              </div>
+              <div class="repo-stat-card">
+                <span class="repo-stat-value" id="repo-pushed">—</span>
+                <span class="repo-stat-label"><i class="bi bi-clock-history" aria-hidden="true"></i> Pushed</span>
+              </div>
+            </div>
+            <div class="repo-terminal" aria-label="TracePoint build terminal style summary">
+              <p><span>$</span> tracepoint status --trust-signal</p>
+              <p id="terminal-line-one">syncing repository metadata…</p>
+              <p id="terminal-line-two">waiting for pull request ledger…</p>
+            </div>
+          </section>
+
+          <aside class="repo-panel repo-board-sidebar" aria-labelledby="build-ledger-title">
+            <div class="repo-panel-header compact">
+              <div>
+                <p class="project-tag">Build ledger</p>
+                <h2 id="build-ledger-title">Why this is convincing</h2>
+              </div>
+            </div>
+            <ul class="repo-proof-list">
+              <li><i class="bi bi-shield-check" aria-hidden="true"></i> Public activity makes progress inspectable.</li>
+              <li><i class="bi bi-git" aria-hidden="true"></i> Pull request summaries show decision history.</li>
+              <li><i class="bi bi-clock" aria-hidden="true"></i> Recent touches prove the flagship is not a static mockup.</li>
+              <li><i class="bi bi-braces" aria-hidden="true"></i> Commit messages expose implementation focus without leaking staff-only flows.</li>
+            </ul>
+          </aside>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section repo-activity-section">
+      <div class="container">
+        <div class="row g-4">
+          <div class="col-lg-7">
+            <section class="repo-panel h-100" aria-labelledby="latest-prs-title">
+              <div class="repo-panel-header">
+                <div>
+                  <p class="project-tag">Last touches</p>
+                  <h2 id="latest-prs-title">Recent pull request summaries</h2>
+                </div>
+                <button class="repo-refresh-btn" type="button" id="repo-refresh"><i class="bi bi-arrow-clockwise" aria-hidden="true"></i> Refresh</button>
+              </div>
+              <div class="repo-feed" id="pull-request-feed" aria-live="polite">
+                <article class="repo-feed-item skeleton-card">
+                  <span></span>
+                  <span></span>
+                  <span></span>
+                </article>
+              </div>
+            </section>
+          </div>
+
+          <div class="col-lg-5">
+            <section class="repo-panel h-100" aria-labelledby="commit-stream-title">
+              <div class="repo-panel-header compact">
+                <div>
+                  <p class="project-tag">Commit stream</p>
+                  <h2 id="commit-stream-title">Recent implementation touches</h2>
+                </div>
+              </div>
+              <div class="commit-stream" id="commit-stream" aria-live="polite">
+                <div class="commit-item skeleton-card"><span></span><span></span></div>
+              </div>
+            </section>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="content-section section-dark section--insights">
+      <div class="container">
+        <header class="section-header">
+          <h2>Implementation approach</h2>
+          <p>This page stays static-host friendly while still feeling dynamic: JavaScript requests public GitHub REST endpoints in the visitor’s browser, renders recent PRs and commits, then falls back gracefully if rate limits or privacy settings block access.</p>
+        </header>
+        <div class="row g-4">
+          <div class="col-md-4">
+            <article class="project-card h-100">
+              <h3>1. Public data only</h3>
+              <p>Use repository metadata, pull requests, and commit endpoints. No tokens are embedded in the portfolio, so no private TracePoint data or staff endpoint details are exposed.</p>
+            </article>
+          </div>
+          <div class="col-md-4">
+            <article class="project-card h-100">
+              <h3>2. GitHub-like renderer</h3>
+              <p>Render a repo header, activity ledger, PR cards, commit stream, branch chips, and terminal-style status copy for a polished proof-of-work experience.</p>
+            </article>
+          </div>
+          <div class="col-md-4">
+            <article class="project-card h-100">
+              <h3>3. Safe future upgrade</h3>
+              <p>If the repo becomes private or needs richer summaries, add a GitHub Action that writes a sanitized JSON activity file to this portfolio site.</p>
+            </article>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container">
+      <h2>Contact</h2>
+      <p>Want a walkthrough of TracePoint’s lifecycle thinking, repository cadence, and deployment direction?</p>
+      <div class="cta-group footer-cta-group" aria-label="Footer calls to action">
+        <a class="btn cta-btn cta-primary" href="mailto:cristinoagapitojr@gmail.com?subject=TracePoint%20walkthrough%20request">Request TracePoint Walkthrough</a>
+        <a class="btn cta-btn cta-secondary" data-repo-link href="https://github.com/tepong32/tracepoint" target="_blank" rel="noopener noreferrer">Inspect Repository</a>
+      </div>
+      <ul class="contact-list">
+        <li><a href="https://github.com/tepong32" target="_blank" rel="noopener noreferrer"><i class="bi bi-github"></i> GitHub</a></li>
+        <li><a href="mailto:cristinoagapitojr@gmail.com"><i class="bi bi-envelope"></i> cristinoagapitojr@gmail.com</a></li>
+        <li><a href="index.html"><i class="bi bi-globe"></i> Portfolio Home</a></li>
+      </ul>
+      <p class="copyright">© <span id="year"></span> Cristino Agapito Jr. TracePoint activity is rendered from public GitHub repository data when available.</p>
+    </div>
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js" integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+  <script src="js/portfolio-refresh.js"></script>
+  <script src="js/tracepoint-live.js"></script>
+</body>
+</html>

--- a/tracepoint.html
+++ b/tracepoint.html
@@ -18,7 +18,10 @@
           <img src="assets/img/smile.png" alt="Portfolio logo" width="30" height="30">
           <span>Cristino Agapito Jr</span>
         </a>
-        <a class="btn btn-outline-light" href="index.html#projects">Back to Projects</a>
+        <div class="tracepoint-nav-actions">
+          <a class="btn btn-outline-light" href="index.html#projects">Back to Projects</a>
+          <a class="btn btn-accent" href="tracepoint-live.html">Live Repo Board</a>
+        </div>
       </div>
     </nav>
   </header>
@@ -56,6 +59,7 @@
   <footer class="site-footer">
     <div class="container">
       <ul class="contact-list">
+        <li><a href="tracepoint-live.html"><i class="bi bi-activity"></i> TracePoint Live Board</a></li>
         <li><a href="https://github.com/tepong32" target="_blank" rel="noopener noreferrer"><i class="bi bi-github"></i> GitHub</a></li>
         <li><a href="mailto:cristinoagapitojr@gmail.com"><i class="bi bi-envelope"></i> cristinoagapitojr@gmail.com</a></li>
       </ul>


### PR DESCRIPTION
### Motivation
- Provide a live, inspectable project board that surfaces public GitHub activity for the TracePoint repository to demonstrate ongoing implementation and proof-of-work.
- Keep the portfolio site static-host friendly while safely attempting to render public repository metadata, recent commits, and PR summaries in the visitor's browser.

### Description
- Add a new page `tracepoint-live.html` that renders a GitHub-inspired repo dashboard, commit stream, and PR feed driven by client-side data.
- Add `js/tracepoint-live.js` which queries the public GitHub REST API, renders repo metadata/PR/commit UI, and falls back to safe placeholder content on rate-limit/private repo errors.
- Extend `portfolio-refresh.css` with a new repo board visual system and responsive styles for the live board, plus small UI styles used by `tracepoint-live.html` and updated pages.
- Update `index.html` and `tracepoint.html` to surface links/buttons to the new live board and adjust project feature actions to include a "View Live Repo Board" option.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9409002c832492120cb62c35b025)