### PR TITLE
Redesign portfolio around practical engineering identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,39 @@
-# tepong32.github.io
-A little better version of my CV. Thanks to Bootstrap!
+# Cristino Agapito Jr Portfolio
 
-Sources:
-https://startbootstrap.com/
-https://bootstrapmade.com
+A lightweight GitHub Pages portfolio for presenting software engineering work focused on process improvement, workflow automation, and practical operational software.
+
+The homepage introduces Cristino Agapito Jr as a Software Engineer before presenting selected projects. The redesign keeps the existing Bootstrap-based static structure and organizes the portfolio around practical engineering themes rather than a long project list.
+
+## Portfolio structure
+
+- **Hero**: concise professional introduction, summary, GitHub link, project CTA, and resume access.
+- **About Me**: accounting-influenced software engineering narrative focused on accuracy, maintainability, and operational efficiency.
+- **Skills**: grouped by languages, frameworks, data and automation, and tools.
+- **What I Enjoy Solving**: minimal overview of workflow automation, process optimization, government digitalization, desktop software, business systems, data management, Excel automation, and AI-assisted software development.
+- **Selected Engineering Projects**: categorized project cards for government process improvement, desktop productivity, and accounting automation.
+
+## Project metadata
+
+Project cards are rendered from `js/portfolio-refresh.js`. The page attempts to load repository metadata from the GitHub API for the `tepong32` account and gracefully falls back to concise static copy if metadata is unavailable.
+
+Each project card is written to answer:
+
+- What problem does this solve?
+- Who is it for?
+- Why is it useful?
+
+## Files
+
+- `index.html` — main GitHub Pages portfolio page.
+- `portfolio-refresh.css` — custom portfolio styling layered on Bootstrap.
+- `js/portfolio-refresh.js` — navigation behavior, footer year, and GitHub repository metadata rendering.
+- `assets/` — existing portfolio image and resume assets.
+
+## Compatibility
+
+This repository remains a static Bootstrap site compatible with GitHub Pages. No build step or additional runtime dependency is required.
+
+## Sources
+
+- Bootstrap: <https://getbootstrap.com/>
+- Bootstrap Icons: <https://icons.getbootstrap.com/>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Cristino Agapito Jr | GovTech Systems Builder</title>
-  <meta name="description" content="GovTech-focused Django Developer and workflow automation builder creating practical systems for LGU operations and citizen services.">
+  <title>Cristino Agapito Jr | Software Engineer</title>
+  <meta name="description" content="Software engineering portfolio for practical workflow automation, process improvement, and operations-focused software.">
   <link rel="icon" type="image/x-icon" href="assets/img/smile.png">
 
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
@@ -26,10 +26,9 @@
           <ul class="navbar-nav ms-auto">
             <li class="nav-item"><a class="nav-link" href="#home">Home</a></li>
             <li class="nav-item"><a class="nav-link" href="#about">About</a></li>
+            <li class="nav-item"><a class="nav-link" href="#skills">Skills</a></li>
             <li class="nav-item"><a class="nav-link" href="#projects">Projects</a></li>
             <li class="nav-item"><a class="nav-link" href="tracepoint-live.html">TracePoint Live</a></li>
-            <li class="nav-item"><a class="nav-link" href="#journal">Engineering Journal</a></li>
-            <li class="nav-item"><a class="nav-link" href="#cv">CV</a></li>
             <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
           </ul>
         </div>
@@ -40,25 +39,24 @@
   <main>
     <section id="home" class="hero-section">
       <div class="container">
-        <div class="row align-items-center g-4">
+        <div class="row align-items-center g-5">
           <div class="col-lg-8">
-            <p class="eyebrow">GovTech-focused Django Developer | Workflow Automation Builder | LGU Systems Process Specialist</p>
-            <h1>Building practical systems for government workflows, internal operations, and real-world citizen services.</h1>
-            <p class="hero-lead">I design and ship process-aware software with clear operational impact for local government teams. Current focus: transforming municipal tracing and assistance workflows into reliable digital systems.</p>
+            <p class="eyebrow">Process improvement • Workflow automation • Practical software</p>
+            <h1>Software Engineer</h1>
+            <p class="hero-lead">Building practical software that improves operations, automates repetitive work, and simplifies complex processes.</p>
+            <p class="hero-summary">I design and build software that helps organizations work more efficiently—from desktop utilities and workflow automation tools to web platforms that improve internal operations and citizen services. Combining software engineering with accounting and process analysis, I focus on creating solutions that are practical, maintainable, and genuinely useful to the people who rely on them.</p>
             <div class="hero-actions cta-group" aria-label="Primary calls to action">
-              <a class="btn cta-btn cta-primary" href="#contact">Book a Systems Consultation</a>
-              <a class="btn cta-btn cta-secondary" href="#projects">Request Portfolio Walkthrough</a>
-              <a class="cta-tertiary" href="tracepoint-live.html">TracePoint Live Board</a>
-              <a class="cta-tertiary" href="assets/teppy.pdf" download>Download CV</a>
+              <a class="btn cta-btn cta-primary" href="#projects">View Projects</a>
+              <a class="btn cta-btn cta-secondary" href="https://github.com/tepong32" target="_blank" rel="noopener noreferrer">GitHub</a>
+              <a class="btn cta-btn cta-secondary" href="assets/teppy.pdf" download>Contact / Resume</a>
             </div>
           </div>
           <div class="col-lg-4">
-            <aside class="status-card" aria-label="Current focus">
-              <p class="badge-label">Active Build</p>
-              <h2>Currently building TracePoint</h2>
-              <p>A case-driven platform for LGU process tracking, citizen assistance visibility, and workflow accountability.</p>
-              <span class="milestone-badge">Milestone: Core Workflow Foundation</span>
-              <a class="repo-live-link" href="tracepoint-live.html"><i class="bi bi-activity" aria-hidden="true"></i> View live development pulse</a>
+            <aside class="status-card" aria-label="Professional focus">
+              <p class="badge-label">Engineering Focus</p>
+              <h2>Software for real workflows</h2>
+              <p>Government digitalization, internal business systems, desktop productivity tools, Excel automation, Django web applications, and AI-assisted software engineering.</p>
+              <a class="repo-live-link" href="tracepoint-live.html"><i class="bi bi-activity" aria-hidden="true"></i> View TracePoint development pulse</a>
             </aside>
           </div>
         </div>
@@ -68,84 +66,41 @@
     <section id="about" class="content-section section--proof">
       <div class="container">
         <header class="section-header">
-          <h2>About</h2>
-          <p>Systems builder mindset, grounded in practical implementation.</p>
+          <h2>About Me</h2>
+          <p>Practical engineering shaped by accounting, process analysis, and operational realities.</p>
         </header>
-        <div class="row g-4">
-          <div class="col-lg-7">
-            <p>I am Cristino Agapito Jr, a developer focused on modernizing public service operations through clear process design and maintainable software architecture. My work combines Django-based backend development with field-informed workflow design.</p>
-            <p>I prioritize traceability, low-friction usability, and deployment-ready solutions that can adapt to policy, personnel, and operational realities in LGU environments.</p>
-          </div>
-          <div class="col-lg-5">
-            <div class="info-panel">
-              <h3>Core strengths</h3>
-              <ul>
-                <li>Django-first web application development</li>
-                <li>Workflow mapping and process automation</li>
-                <li>Internal operations tooling for government teams</li>
-                <li>Documentation and maintainable handover practices</li>
-              </ul>
-            </div>
-          </div>
+        <div class="about-card">
+          <p>I am a software engineer with a background in accounting who enjoys improving the way people work through practical software solutions.</p>
+          <p>Rather than building software for technology's sake, I focus on understanding operational challenges and designing tools that simplify repetitive work, reduce errors, and improve long-term efficiency.</p>
+          <p>My projects range from desktop utilities and Excel automation tools to Django web applications for government and business workflows.</p>
+          <p>I believe good software should solve real problems while remaining approachable for the people who use it.</p>
         </div>
       </div>
     </section>
 
-    <section id="build-systems" class="content-section">
+    <section id="skills" class="content-section">
       <div class="container">
         <header class="section-header">
-          <h2>How I Build Systems (AI-assisted, engineer-directed)</h2>
-          <p>A disciplined workflow that keeps human engineering judgment accountable at every stage.</p>
+          <h2>Skills</h2>
+          <p>Grouped around the tools I use to build maintainable workflow-focused systems.</p>
         </header>
+        <div class="row g-4">
+          <div class="col-md-6 col-xl-3"><div class="skill-card h-100"><h3>Languages</h3><ul><li>Python</li><li>JavaScript</li><li>HTML</li><li>CSS</li><li>SQL</li></ul></div></div>
+          <div class="col-md-6 col-xl-3"><div class="skill-card h-100"><h3>Frameworks &amp; Libraries</h3><ul><li>Django</li><li>Bootstrap</li><li>Tkinter</li></ul></div></div>
+          <div class="col-md-6 col-xl-3"><div class="skill-card h-100"><h3>Data &amp; Automation</h3><ul><li>Excel</li><li>OpenPyXL</li><li>SQLite through Django ORM</li><li>Data Processing</li></ul></div></div>
+          <div class="col-md-6 col-xl-3"><div class="skill-card h-100"><h3>Tools</h3><ul><li>Git</li><li>GitHub</li><li>VS Code</li><li>Codex</li><li>Cursor</li></ul></div></div>
+        </div>
+      </div>
+    </section>
 
-        <div class="trust-block">
-          <ol class="workflow-timeline" aria-label="Five-step system build workflow">
-            <li class="timeline-step">
-              <span class="step-number">1</span>
-              <div>
-                <h3>Process discovery and constraint mapping</h3>
-                <p>I document operational realities, policy constraints, stakeholder responsibilities, and data boundaries before any build starts.</p>
-              </div>
-            </li>
-            <li class="timeline-step">
-              <span class="step-number">2</span>
-              <div>
-                <h3>Solution framing and architecture decisions</h3>
-                <p>I choose architecture and integration paths based on maintainability, clarity of ownership, and realistic deployment conditions.</p>
-              </div>
-            </li>
-            <li class="timeline-step">
-              <span class="step-number">3</span>
-              <div>
-                <h3>AI-assisted drafting/prototyping</h3>
-                <p>I use AI to accelerate draft generation and prototyping while keeping design control, code intent, and acceptance criteria engineer-led.</p>
-              </div>
-            </li>
-            <li class="timeline-step">
-              <span class="step-number">4</span>
-              <div>
-                <h3>Human validation, edge-case hardening, and documentation</h3>
-                <p>I validate behavior against edge cases, harden workflows for operational exceptions, and prepare handover-ready technical documentation.</p>
-              </div>
-            </li>
-            <li class="timeline-step">
-              <span class="step-number">5</span>
-              <div>
-                <h3>Deployment readiness and handover</h3>
-                <p>I finalize deployment checklists, accountability mapping, and support expectations so teams can run the system with confidence.</p>
-              </div>
-            </li>
-          </ol>
-
-          <div class="trust-principles">
-            <h3>Trust Principles</h3>
-            <ul>
-              <li><i class="bi bi-check2-circle" aria-hidden="true"></i>Traceability</li>
-              <li><i class="bi bi-check2-circle" aria-hidden="true"></i>Maintainability</li>
-              <li><i class="bi bi-check2-circle" aria-hidden="true"></i>Data responsibility</li>
-              <li><i class="bi bi-check2-circle" aria-hidden="true"></i>Auditability</li>
-            </ul>
-          </div>
+    <section id="solving" class="content-section section--insights">
+      <div class="container">
+        <header class="section-header">
+          <h2>What I Enjoy Solving</h2>
+          <p>Work where software can clarify responsibilities, reduce repetition, and improve operational reliability.</p>
+        </header>
+        <div class="interest-list" aria-label="Problem areas">
+          <span>Workflow automation</span><span>Process optimization</span><span>Government digitalization</span><span>Desktop software</span><span>Business systems</span><span>Data management</span><span>Excel automation</span><span>AI-assisted software development</span>
         </div>
       </div>
     </section>
@@ -153,119 +108,10 @@
     <section id="projects" class="content-section section-dark">
       <div class="container">
         <header class="section-header">
-          <h2>Featured Projects</h2>
-          <p>Focused builds with operational outcomes and practical deployment intent.</p>
+          <h2>Selected Engineering Projects</h2>
+          <p>Projects are grouped by the operational problems they support. Repository metadata is loaded from GitHub when available.</p>
         </header>
-
-        <article class="feature-card">
-          <div>
-            <p class="project-tag">Featured Active Project</p>
-            <h3>TracePoint</h3>
-            <p class="case-label">1. Context / Problem</p>
-            <p>TracePoint addresses fragmented case handling in LGU workflows where manual handoffs and siloed logs create delays, weak visibility, and inconsistent accountability.</p>
-            <p class="case-label">2. System / Architecture approach</p>
-            <p>The platform uses a modular Django workflow core for case intake, routing, status transitions, and office-level views, designed for gradual integration with role-based access and reporting modules.</p>
-            <p class="case-label">TracePoint architecture snapshot</p>
-            <dl class="case-meta">
-              <dt>Actors</dt>
-              <dd>Frontline encoders, receiving offices, reviewers, and decision-makers.</dd>
-              <dt>Core modules</dt>
-              <dd>Case registry, routing queue, status timeline, and operational dashboard.</dd>
-              <dt>Data / events tracked</dt>
-              <dd>Intake timestamps, assignment transitions, action notes, status changes, and resolution checkpoints.</dd>
-              <dt>Governance / audit considerations</dt>
-              <dd>Immutable transition history, role-aligned permissions, and evidence-ready activity logs.</dd>
-            </dl>
-            <p class="case-label">3. Constraints handled</p>
-            <p>Designed to align with policy changes, office-specific process variations, mixed digital maturity of users, and uneven source-data quality from paper-origin records.</p>
-            <p class="case-label">4. Outcome / expected operational impact</p>
-            <p>Expected outcomes include faster case turnaround, clearer cross-office ownership, and stronger audit readiness for service delivery oversight.</p>
-          </div>
-          <div class="feature-actions">
-            <a class="btn btn-accent align-self-start" href="tracepoint.html">Open Project Brief</a>
-            <a class="btn btn-outline-light align-self-start" href="tracepoint-live.html">View Live Repo Board</a>
-          </div>
-        </article>
-
-        <div class="row g-4 project-grid">
-          <div class="col-md-6 col-xl-4">
-            <article class="project-card h-100">
-              <h3>Excel Workflow Automation Toolkit</h3>
-              <p class="case-label">1. Context / Problem</p>
-              <p>Internal teams spent significant time on repetitive encoding and manual consolidation of recurring reports.</p>
-              <p class="case-label">2. System / Architecture approach</p>
-              <p>Built reusable spreadsheet templates and automation scripts with controlled input zones and output-ready summary sheets.</p>
-              <p class="case-label">3. Constraints handled</p>
-              <p>Configured for existing office approval routines, varied staff tool proficiency, and inconsistent source entries across units.</p>
-              <p class="case-label">4. Outcome / expected operational impact</p>
-              <p>Improves report preparation speed, reduces encoding errors, and standardizes internal document outputs.</p>
-              <span class="milestone-badge">Milestone: Operational Toolkit</span>
-            </article>
-          </div>
-          <div class="col-md-6 col-xl-4">
-            <article class="project-card h-100">
-              <h3>Legacy LGU Assistance Learnings</h3>
-              <p class="case-label">1. Context / Problem</p>
-              <p>Manual assistance workflows lacked unified visibility, producing repeated verification work and delayed service completion.</p>
-              <p class="case-label">2. System / Architecture approach</p>
-              <p>Compiled field observations into a structured learning archive with process maps, bottleneck patterns, and migration-ready requirements.</p>
-              <p class="case-label">3. Constraints handled</p>
-              <p>Captured policy-dependent process steps, human handoff patterns, and reliability issues from handwritten or partial records.</p>
-              <p class="case-label">4. Outcome / expected operational impact</p>
-              <p>Provides a decision baseline for phased digital transition planning and lowers implementation risk for new systems.</p>
-              <span class="milestone-badge">Milestone: Lessons Archive</span>
-            </article>
-          </div>
-          <div class="col-md-6 col-xl-4">
-            <article class="project-card h-100">
-              <h3>Operations Documentation Framework</h3>
-              <p class="case-label">1. Context / Problem</p>
-              <p>Critical operational knowledge was distributed across teams, making onboarding and continuity highly dependent on individual memory.</p>
-              <p class="case-label">2. System / Architecture approach</p>
-              <p>Designed a standardized documentation framework combining workflow narratives, role responsibilities, and integration touchpoints.</p>
-              <p class="case-label">3. Constraints handled</p>
-              <p>Structured for policy updates, approval-chain changes, and cross-office coordination with varying levels of process formalization.</p>
-              <p class="case-label">4. Outcome / expected operational impact</p>
-              <p>Strengthens institutional memory, accelerates staff ramp-up, and improves readiness for future platform integration.</p>
-              <span class="milestone-badge">Milestone: Documentation Baseline</span>
-            </article>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="journal" class="content-section section--insights">
-      <div class="container">
-        <header class="section-header">
-          <h2>Engineering Journal</h2>
-          <p>Build reflections from active systems work.</p>
-        </header>
-        <div class="row g-4">
-          <div class="col-md-6">
-            <article class="journal-entry h-100">
-              <h3>Designing for process reality, not just ideal flow</h3>
-              <p>I map administrative bottlenecks first, then implement software that respects actual office behavior. This avoids fragile systems that fail under real-world exceptions.</p>
-            </article>
-          </div>
-          <div class="col-md-6">
-            <article class="journal-entry h-100">
-              <h3>Making auditability a default feature</h3>
-              <p>Reliable public systems need trace logs and clear ownership transitions. I treat audit trails as a core requirement, not a later enhancement.</p>
-            </article>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="cv" class="content-section section-dark section--proof">
-      <div class="container">
-        <header class="section-header">
-          <h2>Resume / CV</h2>
-          <p>Download the latest profile for roles in GovTech software and operations-focused engineering.</p>
-        </header>
-        <a class="btn btn-accent" href="assets/teppy.pdf" download>
-          <i class="bi bi-download me-2" aria-hidden="true"></i>Download CV (PDF)
-        </a>
+        <div id="project-catalog" class="project-catalog" aria-live="polite"></div>
       </div>
     </section>
   </main>
@@ -273,67 +119,18 @@
   <footer id="contact" class="site-footer">
     <div class="container">
       <h2>Contact</h2>
-      <p>Let’s collaborate on practical government systems and internal process modernization.</p>
-
+      <p>Let’s connect about practical software, workflow automation, and process-focused engineering.</p>
       <div class="cta-group footer-cta-group" aria-label="Contact calls to action">
-        <a class="btn cta-btn cta-primary" href="mailto:cristinoagapitojr@gmail.com?subject=Systems%20Consultation%20Request">Book a Systems Consultation</a>
-        <a class="btn cta-btn cta-secondary" href="mailto:cristinoagapitojr@gmail.com?subject=Portfolio%20Walkthrough%20Request">Request Portfolio Walkthrough</a>
-        <a class="cta-tertiary" href="tracepoint-live.html">TracePoint Live Board</a>
-        <a class="cta-tertiary" href="assets/teppy.pdf" download>Download CV</a>
+        <a class="btn cta-btn cta-primary" href="mailto:cristinoagapitojr@gmail.com">Contact</a>
+        <a class="btn cta-btn cta-secondary" href="assets/teppy.pdf" download>Download Resume</a>
+        <a class="cta-tertiary" href="https://github.com/tepong32" target="_blank" rel="noopener noreferrer">GitHub</a>
       </div>
-
-      <div class="contact-prompt" role="form" aria-label="Project inquiry prompt">
-        <h3>Project Inquiry Snapshot</h3>
-        <p>Share these details in your email so I can prepare a targeted response:</p>
-        <form class="inquiry-form" action="mailto:cristinoagapitojr@gmail.com" method="post" enctype="text/plain">
-          <div class="inquiry-grid">
-            <label>
-              Scope
-              <select name="Scope" required>
-                <option value="" selected disabled>Select scope</option>
-                <option>New build</option>
-                <option>Modernization / migration</option>
-                <option>Workflow automation enhancement</option>
-              </select>
-            </label>
-            <label>
-              Timeline
-              <select name="Timeline" required>
-                <option value="" selected disabled>Select timeline</option>
-                <option>2–4 weeks</option>
-                <option>1–2 months</option>
-                <option>3+ months</option>
-              </select>
-            </label>
-            <label>
-              Office type
-              <select name="Office Type" required>
-                <option value="" selected disabled>Select office type</option>
-                <option>Municipal / city office</option>
-                <option>Provincial office</option>
-                <option>Inter-office / multi-unit team</option>
-              </select>
-            </label>
-            <label>
-              Challenge area
-              <select name="Challenge Area" required>
-                <option value="" selected disabled>Select challenge area</option>
-                <option>Case tracking visibility</option>
-                <option>Routing and approvals</option>
-                <option>Reporting and audit logs</option>
-              </select>
-            </label>
-          </div>
-          <button class="btn cta-btn cta-secondary inquiry-submit" type="submit">Send Inquiry Details</button>
-        </form>
-      </div>
-
       <ul class="contact-list">
         <li><a href="https://github.com/tepong32" target="_blank" rel="noopener noreferrer"><i class="bi bi-github"></i> GitHub</a></li>
         <li><a href="mailto:cristinoagapitojr@gmail.com"><i class="bi bi-envelope"></i> cristinoagapitojr@gmail.com</a></li>
         <li><a href="https://tepong32.github.io" target="_blank" rel="noopener noreferrer"><i class="bi bi-globe"></i> Portfolio</a></li>
       </ul>
-      <p class="copyright">© <span id="year"></span> Cristino Agapito Jr. Built as static HTML/CSS for GitHub Pages, structured for future Django and Vue component migration.</p>
+      <p class="copyright">© <span id="year"></span> Cristino Agapito Jr. Built as a lightweight Bootstrap portfolio for GitHub Pages.</p>
     </div>
   </footer>
 

--- a/js/portfolio-refresh.js
+++ b/js/portfolio-refresh.js
@@ -14,4 +14,139 @@
       }
     });
   });
+
+  const projectCatalog = document.getElementById('project-catalog');
+  if (!projectCatalog) {
+    return;
+  }
+
+  const githubUser = 'tepong32';
+  const categories = [
+    {
+      title: 'Government Process Improvement',
+      projects: [
+        {
+          name: 'TracePoint',
+          match: ['tracepoint', 'trace-point'],
+          problem: 'Supports lifecycle-driven government assistance workflows that need clearer intake, continuity, and staff accountability.',
+          audience: 'Public-facing citizens and secured role-based staff workflows.',
+          value: 'Keeps requests visible as lifecycle entities while reinforcing auditability, recoverability, and practical service continuity.',
+          technologies: ['Django', 'Python', 'Bootstrap']
+        },
+        {
+          name: 'GRAND',
+          note: 'Original prototype that eventually evolved into TracePoint.',
+          match: ['grand'],
+          problem: 'Explores earlier digital assistance workflow ideas for public service operations.',
+          audience: 'Government teams evaluating structured assistance and routing workflows.',
+          value: 'Preserves the prototype lineage behind the current TracePoint direction.',
+          technologies: ['Django', 'Python', 'Bootstrap']
+        }
+      ]
+    },
+    {
+      title: 'Desktop Productivity',
+      projects: [
+        {
+          name: 'TraceSync',
+          match: ['tracesync', 'trace-sync'],
+          problem: 'Helps reduce repetitive desktop workflow steps around tracking and synchronization tasks.',
+          audience: 'Users who need practical desktop support for recurring operational work.',
+          value: 'Turns repeatable work into a more consistent utility-driven process.',
+          technologies: ['Python', 'Tkinter']
+        },
+        {
+          name: 'Excel Companion',
+          match: ['excel-companion', 'excelcompanion', 'excel_companion'],
+          problem: 'Assists with recurring spreadsheet preparation and data handling work.',
+          audience: 'Teams that rely on Excel for operational reports and working documents.',
+          value: 'Improves consistency in spreadsheet-based workflows without forcing a larger platform migration.',
+          technologies: ['Python', 'Excel', 'OpenPyXL']
+        }
+      ]
+    },
+    {
+      title: 'Accounting Automation',
+      projects: [
+        {
+          name: 'Accounting repository',
+          match: ['accounting'],
+          problem: 'Supports accounting-related automation and operational record workflows.',
+          audience: 'Users working with accounting files, reports, or repeatable back-office tasks.',
+          value: 'Applies an accuracy-focused accounting background to practical software automation.',
+          technologies: ['Python', 'Excel', 'Data Processing']
+        },
+        {
+          name: 'Payroll/reporting automation',
+          match: ['payroll', 'reporting', 'report'],
+          problem: 'Targets repetitive payroll or reporting preparation work.',
+          audience: 'Teams handling recurring payroll or internal reporting outputs.',
+          value: 'Reduces manual consolidation effort while keeping the presentation concise when repository details are unavailable.',
+          technologies: ['Python', 'Excel', 'OpenPyXL']
+        }
+      ]
+    }
+  ];
+
+  function normalize(value) {
+    return value.toLowerCase().replace(/[^a-z0-9]/g, '');
+  }
+
+  function findRepo(repos, project) {
+    const matches = project.match.map(normalize);
+    return repos.find((repo) => matches.includes(normalize(repo.name))) || repos.find((repo) => matches.some((match) => normalize(repo.name).includes(match)));
+  }
+
+  function repoDescription(repo) {
+    if (!repo) {
+      return 'Repository metadata is unavailable.';
+    }
+    return repo.description || 'No repository description provided.';
+  }
+
+  function repoLink(repo, project) {
+    if (repo) {
+      return repo.html_url;
+    }
+    return `https://github.com/${githubUser}?tab=repositories&q=${encodeURIComponent(project.name)}`;
+  }
+
+  function renderProjects(repos) {
+    projectCatalog.innerHTML = categories.map((category) => `
+      <section class="project-category" aria-labelledby="${normalize(category.title)}">
+        <h3 id="${normalize(category.title)}">${category.title}</h3>
+        <div class="row g-4">
+          ${category.projects.map((project) => {
+            const repo = findRepo(repos, project);
+            const homepage = repo && repo.homepage ? repo.homepage : '';
+            const language = repo && repo.language ? repo.language : '';
+            const technologies = Array.from(new Set([...project.technologies, language].filter(Boolean)));
+            return `
+              <div class="col-md-6">
+                <article class="project-card h-100">
+                  <p class="project-tag">${project.note || category.title}</p>
+                  <h4>${project.name}</h4>
+                  <p class="repo-description">${repoDescription(repo)}</p>
+                  <dl class="project-answers">
+                    <dt>Problem</dt><dd>${project.problem}</dd>
+                    <dt>For</dt><dd>${project.audience}</dd>
+                    <dt>Useful because</dt><dd>${project.value}</dd>
+                  </dl>
+                  <div class="tech-list">${technologies.map((tech) => `<span>${tech}</span>`).join('')}</div>
+                  <div class="project-links">
+                    <a href="${repoLink(repo, project)}" target="_blank" rel="noopener noreferrer">Repository</a>
+                    ${homepage ? `<a href="${homepage}" target="_blank" rel="noopener noreferrer">Live demo</a>` : ''}
+                  </div>
+                </article>
+              </div>`;
+          }).join('')}
+        </div>
+      </section>
+    `).join('');
+  }
+
+  fetch(`https://api.github.com/users/${githubUser}/repos?per_page=100&sort=updated`)
+    .then((response) => (response.ok ? response.json() : []))
+    .then(renderProjects)
+    .catch(() => renderProjects([]));
 })();

--- a/portfolio-refresh.css
+++ b/portfolio-refresh.css
@@ -9,25 +9,23 @@
   --space-6: 3rem;
   --space-7: 3.5rem;
   --space-8: 4rem;
-  --bg-primary: #0b1220;
-  --bg-secondary: #111b2f;
-  --bg-surface: #1a2740;
-  --text-primary: #ecf2ff;
-  --text-muted: #b1bfd9;
-  --accent: #3ea6ff;
-  --accent-soft: rgba(62, 166, 255, 0.18);
-  --border: rgba(255, 255, 255, 0.12);
+  --bg-primary: #f7f8fb;
+  --bg-secondary: #ffffff;
+  --bg-surface: #eef2f7;
+  --text-primary: #172033;
+  --text-muted: #5c677a;
+  --accent: #265d8f;
+  --accent-soft: rgba(38, 93, 143, 0.1);
+  --border: rgba(23, 32, 51, 0.12);
 }
 
-* {
-  box-sizing: border-box;
-}
+* { box-sizing: border-box; }
 
 body {
   margin: 0;
   font-family: 'Inter', sans-serif;
   color: var(--text-primary);
-  background: linear-gradient(180deg, #070d18 0%, #0b1220 45%, #0e1729 100%);
+  background: var(--bg-primary);
   line-height: 1.7;
   font-size: 1rem;
 }
@@ -35,13 +33,11 @@ body {
 .site-header {
   border-bottom: 1px solid var(--border);
   backdrop-filter: blur(12px);
-  background: rgba(6, 11, 20, 0.88);
+  background: rgba(255, 255, 255, 0.92);
 }
 
 .navbar-brand,
-.nav-link {
-  color: var(--text-primary);
-}
+.nav-link { color: var(--text-primary); }
 
 .navbar-brand {
   display: inline-flex;
@@ -50,1035 +46,122 @@ body {
   font-weight: 700;
 }
 
-.nav-link {
-  color: var(--text-muted);
-  font-weight: 500;
-}
-
+.nav-link { color: var(--text-muted); font-weight: 500; }
 .nav-link:hover,
-.nav-link:focus {
-  color: var(--text-primary);
-}
+.nav-link:focus { color: var(--accent); }
+.navbar-toggler { border-color: var(--border); }
 
-.navbar-toggler {
-  border-color: var(--border);
-}
-
-.navbar-toggler-icon {
-  filter: invert(1);
-}
-
-.hero-section {
-  padding: calc(var(--space-8) + var(--space-3)) 0 var(--space-8);
-}
+.hero-section { padding: calc(var(--space-8) + var(--space-3)) 0 var(--space-8); background: #fff; }
 
 .eyebrow {
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: #8fb8e8;
+  color: var(--accent);
   font-weight: 700;
   font-size: 0.75rem;
   margin-bottom: var(--space-2);
 }
 
-h1,
-h2,
-h3 {
+h1, h2, h3, h4 {
   line-height: 1.2;
   margin-bottom: var(--space-2);
   letter-spacing: -0.01em;
   font-weight: 700;
 }
 
-h1 {
-  font-size: clamp(2.25rem, 4.25vw, 3.4rem);
-  max-width: 16ch;
-  font-weight: 800;
-  letter-spacing: -0.02em;
-}
+h1 { font-size: clamp(2.75rem, 6vw, 5rem); max-width: 11ch; font-weight: 800; letter-spacing: -0.04em; }
+h2 { font-size: clamp(1.6rem, 2.25vw, 2.2rem); }
+h3 { font-size: clamp(1.15rem, 1.6vw, 1.35rem); }
+h4 { font-size: 1.15rem; }
 
-h2 {
-  font-size: clamp(1.6rem, 2.25vw, 2.2rem);
-}
-
-h3 {
-  font-size: clamp(1.15rem, 1.6vw, 1.35rem);
-}
-
-.hero-lead,
+.hero-lead { color: var(--text-primary); font-size: clamp(1.15rem, 1.8vw, 1.45rem); max-width: 56ch; }
+.hero-summary,
 .section-header p,
 .project-card p,
-.journal-entry p,
-.feature-card p,
-.info-panel,
-footer p {
-  color: var(--text-muted);
-}
+.about-card p,
+.status-card p,
+.site-footer p { color: var(--text-muted); }
+.hero-summary { max-width: 72ch; }
 
-.hero-lead {
-  font-size: clamp(1.05rem, 1.4vw, 1.2rem);
-  max-width: 60ch;
-}
-
-.hero-actions {
-  margin-top: 1.4rem;
-}
-
-
-.cta-group {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.8rem;
-  margin-top: 1.4rem;
-}
-
-.cta-btn {
-  border-radius: 0.7rem;
-  font-weight: 700;
-  padding: 0.65rem 1.05rem;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
-}
-
-.cta-primary {
-  border: 1px solid transparent;
-  background: var(--accent);
-  color: #03111f;
-}
-
-.cta-primary:hover {
-  background: #67b8ff;
-  color: #03111f;
-  transform: translateY(-1px);
-}
-
-.cta-secondary {
-  border: 1px solid rgba(126, 189, 255, 0.65);
-  color: #d8ebff;
-  background: transparent;
-}
-
-.cta-secondary:hover {
-  border-color: #9ed0ff;
-  color: #f1f8ff;
-  background: rgba(62, 166, 255, 0.12);
-}
-
-.cta-tertiary {
-  color: #b9dfff;
-  text-decoration: underline;
-  text-underline-offset: 0.2em;
-  text-decoration-color: rgba(185, 223, 255, 0.55);
-  font-weight: 600;
-  padding: 0.35rem 0.2rem;
-}
-
-.cta-tertiary:hover {
-  color: #ffffff;
-  text-decoration-color: currentColor;
-}
-
+.cta-group { display: flex; flex-wrap: wrap; align-items: center; gap: 0.8rem; margin-top: 1.4rem; }
+.cta-btn { border-radius: 0.55rem; font-weight: 700; padding: 0.65rem 1.05rem; transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, transform 0.2s ease; }
+.cta-primary { border: 1px solid transparent; background: var(--accent); color: #fff; }
+.cta-primary:hover { background: #1e4b73; color: #fff; transform: translateY(-1px); }
+.cta-secondary { border: 1px solid rgba(38, 93, 143, 0.35); color: var(--accent); background: transparent; }
+.cta-secondary:hover { border-color: var(--accent); color: #1e4b73; background: var(--accent-soft); }
+.cta-tertiary { color: var(--accent); text-decoration: underline; text-underline-offset: 0.2em; font-weight: 600; padding: 0.35rem 0.2rem; }
+.cta-tertiary:hover { color: #173953; }
 .cta-btn:focus-visible,
-.cta-tertiary:focus-visible,
-.inquiry-form select:focus-visible {
-  outline: 3px solid rgba(98, 188, 255, 0.62);
-  outline-offset: 2px;
-}
-
-.footer-cta-group {
-  margin-bottom: 1.2rem;
-}
-
-.contact-prompt {
-  border: 1px solid var(--border);
-  border-radius: 0.9rem;
-  padding: 1rem;
-  background: rgba(19, 31, 52, 0.76);
-  margin-bottom: 1.2rem;
-}
-
-.contact-prompt h3 {
-  margin-bottom: 0.45rem;
-  font-size: 1.08rem;
-}
-
-.inquiry-grid {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 0.75rem;
-  margin: 0.9rem 0;
-}
-
-.inquiry-form label {
-  display: grid;
-  gap: 0.38rem;
-  color: #d7e9ff;
-  font-weight: 600;
-  font-size: 0.9rem;
-}
-
-.inquiry-form select {
-  width: 100%;
-  border-radius: 0.58rem;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  background: rgba(7, 12, 21, 0.92);
-  color: var(--text-primary);
-  padding: 0.55rem 0.65rem;
-}
-
-.inquiry-submit {
-  margin-top: 0.2rem;
-}
-
-.btn-accent {
-  border: 1px solid #88ccff;
-  background: var(--accent);
-  color: #03111f;
-  font-weight: 700;
-  box-shadow: 0 8px 20px rgba(10, 54, 96, 0.32);
-  transition: transform 180ms ease, box-shadow 220ms ease, border-color 220ms ease, background-color 220ms ease;
-}
-
-.btn-accent:hover,
-.btn-accent:focus {
-  background: #7bbfff;
-  color: #03111f;
-  border-color: #d7ecff;
-  transform: translateY(-2px);
-  box-shadow: 0 14px 26px rgba(33, 114, 184, 0.3);
-}
-
-.btn-outline-light {
-  transition: transform 180ms ease, box-shadow 220ms ease, border-color 220ms ease;
-}
-
-.btn-outline-light:hover,
-.btn-outline-light:focus {
-  transform: translateY(-2px);
-  border-color: #c9e5ff;
-  box-shadow: 0 10px 20px rgba(2, 8, 16, 0.44);
-}
+.cta-tertiary:focus-visible { outline: 3px solid rgba(38, 93, 143, 0.28); outline-offset: 2px; }
 
 .status-card,
-.info-panel,
-.project-card,
-.feature-card,
-.journal-entry {
+.about-card,
+.skill-card,
+.project-card {
   border: 1px solid var(--border);
   border-radius: 1rem;
-  background: rgba(23, 34, 56, 0.78);
+  background: var(--bg-secondary);
   padding: var(--space-3);
-  transition: transform 220ms ease, box-shadow 220ms ease, border-color 220ms ease, background-color 220ms ease;
-  box-shadow: 0 8px 18px rgba(1, 8, 18, 0.25);
+  box-shadow: 0 12px 28px rgba(23, 32, 51, 0.06);
 }
 
-.feature-card:hover,
-.project-card:hover,
-.journal-entry:hover,
-.info-panel:hover,
-.status-card:hover {
-  transform: translateY(-4px);
-  border-color: rgba(147, 201, 255, 0.5);
-  box-shadow: 0 16px 32px rgba(4, 22, 44, 0.45);
-  background: rgba(27, 41, 66, 0.92);
-}
+.status-card { background: #f8fafc; }
+.badge-label { color: var(--accent); text-transform: uppercase; letter-spacing: 0.12em; font-size: 0.72rem; font-weight: 700; margin-bottom: var(--space-1); }
 
-.badge-label {
-  color: var(--accent);
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  font-size: 0.72rem;
-  font-weight: 700;
-  margin-bottom: var(--space-1);
-}
+.content-section { position: relative; padding: var(--space-8) 0; }
+.content-section::before { content: ""; position: absolute; top: 0; left: 0; right: 0; height: 1px; background: linear-gradient(90deg, transparent 0%, rgba(38, 93, 143, 0.24) 20%, rgba(38, 93, 143, 0.24) 80%, transparent 100%); }
+.section-header { margin-bottom: var(--space-4); max-width: 760px; }
+.section-header h2 { margin-bottom: var(--space-2); }
+.section-header p { margin: 0; max-width: 62ch; }
+.section-dark { background: #edf2f7; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
 
-.milestone-badge {
-  display: inline-block;
-  margin-top: var(--space-2);
-  padding: var(--space-1) var(--space-2);
+.skill-card ul { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.35rem; color: var(--text-muted); }
+.skill-card li::before { content: "•"; color: var(--accent); margin-right: 0.5rem; }
+
+.interest-list { display: flex; flex-wrap: wrap; gap: 0.75rem; }
+.interest-list span,
+.tech-list span {
+  display: inline-flex;
+  border: 1px solid var(--border);
   border-radius: 999px;
-  border: 1px solid rgba(126, 189, 255, 0.4);
-  background: var(--accent-soft);
-  color: #c7e6ff;
-  font-size: 0.72rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+  background: #fff;
+  color: #31425c;
+  padding: 0.45rem 0.75rem;
   font-weight: 600;
-}
-
-.content-section {
-  position: relative;
-  padding: var(--space-8) 0;
-}
-
-.content-section::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 1px;
-  background: linear-gradient(90deg, transparent 0%, rgba(118, 167, 214, 0.35) 20%, rgba(118, 167, 214, 0.35) 80%, transparent 100%);
-}
-
-.content-section::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  pointer-events: none;
-  background-image:
-    linear-gradient(90deg, rgba(157, 198, 236, 0.05) 1px, transparent 1px),
-    linear-gradient(180deg, rgba(157, 198, 236, 0.04) 1px, transparent 1px);
-  background-size: 48px 48px;
-  mask-image: linear-gradient(180deg, transparent, #000 18%, #000 82%, transparent);
-  opacity: 0.35;
-}
-
-.section-header {
-  margin-bottom: var(--space-4);
-  max-width: 760px;
-}
-
-.section-header h2 {
-  margin-bottom: var(--space-2);
-}
-
-.section-header p {
-  margin: 0;
-  max-width: 62ch;
-}
-
-.section--proof {
-  --section-accent: #6ab5ff;
-}
-
-.section--cases {
-  --section-accent: #8dc8ff;
-}
-
-.section--insights {
-  --section-accent: #7cb8ee;
-}
-
-.section--proof .section-header h2,
-.section--cases .section-header h2,
-.section--insights .section-header h2 {
-  position: relative;
-  padding-left: var(--space-3);
-}
-
-.section--proof .section-header h2::before,
-.section--cases .section-header h2::before,
-.section--insights .section-header h2::before {
-  content: "";
-  position: absolute;
-  left: 0;
-  top: 0.2em;
-  bottom: 0.2em;
-  width: 2px;
-  background: linear-gradient(180deg, transparent, var(--section-accent), transparent);
-}
-
-.section--proof .section-header::after,
-.section--cases .section-header::after,
-.section--insights .section-header::after {
-  content: "";
-  display: block;
-  width: min(340px, 75%);
-  margin-top: var(--space-2);
-  border-top: 1px dashed color-mix(in srgb, var(--section-accent), transparent 40%);
-}
-
-.section-dark {
-  background: rgba(6, 12, 22, 0.7);
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.feature-card {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-2);
-  margin-bottom: var(--space-3);
-}
-
-.project-tag {
-  margin-bottom: var(--space-1);
-  color: #9ec6ef;
-  font-weight: 700;
-  font-size: 0.75rem;
-  letter-spacing: 0.09em;
-  text-transform: uppercase;
-}
-
-.feature-list {
-  margin: 0;
-  padding-left: var(--space-3);
-  color: var(--text-muted);
-}
-
-.project-card p,
-.journal-entry p,
-.feature-card p,
-.info-panel,
-.feature-list,
-.info-panel ul {
-  font-size: 0.97rem;
-}
-
-.project-card > * + *,
-.feature-card > * + *,
-.journal-entry > * + *,
-.info-panel > * + * {
-  margin-top: var(--space-2);
-}
-
-.journal-entry h3,
-.project-card h3,
-.feature-card h3 {
-  font-weight: 650;
-}
-
-.site-footer {
-  padding: var(--space-7) 0;
-  background: #050a14;
-}
-
-.contact-list {
-  list-style: none;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2) var(--space-4);
-}
-
-.contact-list a {
-  color: #bfdbff;
-  text-decoration: none;
-}
-
-.contact-list a:hover,
-.contact-list a:focus {
-  color: #fff;
-  text-decoration: underline;
-}
-
-.copyright {
-  margin-top: var(--space-3);
   font-size: 0.9rem;
 }
 
-
-.trust-block {
-  border: 1px solid rgba(126, 189, 255, 0.4);
-  border-radius: 1rem;
-  background: linear-gradient(160deg, rgba(17, 31, 56, 0.9), rgba(13, 23, 40, 0.85));
-  padding: 1.4rem;
-  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.2);
-}
-
-.workflow-timeline {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.9rem;
-}
-
-.timeline-step {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.9rem;
-  align-items: start;
-  border: 1px solid var(--border);
-  border-radius: 0.85rem;
-  background: rgba(20, 31, 51, 0.75);
-  padding: 0.85rem 0.95rem;
-}
-
-.step-number {
-  width: 1.9rem;
-  height: 1.9rem;
-  border-radius: 50%;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--accent-soft);
-  border: 1px solid rgba(126, 189, 255, 0.45);
-  color: #c7e6ff;
-  font-weight: 700;
-  line-height: 1;
-  margin-top: 0.1rem;
-}
-
-.timeline-step h3 {
-  margin-bottom: 0.3rem;
-  font-size: 1.02rem;
-}
-
-.timeline-step p {
-  margin-bottom: 0;
-  color: var(--text-muted);
-}
-
-.trust-principles {
-  margin-top: 1.2rem;
-  padding-top: 1rem;
-  border-top: 1px dashed rgba(126, 189, 255, 0.4);
-}
-
-.trust-principles h3 {
-  margin-bottom: 0.6rem;
-}
-
-.trust-principles ul {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.45rem 0.85rem;
-}
-
-.trust-principles li {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  color: #d7ebff;
-  font-weight: 500;
-}
-
-.trust-principles i {
-  color: var(--accent);
-}
-
-@media (max-width: 991px) {
-  .hero-section {
-    padding-top: calc(var(--space-8) + var(--space-1));
-  }
-
-  .feature-card {
-    flex-direction: column;
-  }
-}
-
-@media (min-width: 1200px) {
-  .credibility-strip {
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-  }
-}
-
-@media (max-width: 767px) {
-  .content-section {
-    padding: var(--space-6) 0;
-  }
-
-  .content-section::after {
-    background-size: 32px 32px;
-  }
-
-  .cta-group .cta-btn,
-  .cta-group .cta-tertiary,
-  .inquiry-submit {
-    width: 100%;
-    text-align: center;
-  }
-
-  .inquiry-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .timeline-step {
-    grid-template-columns: 1fr;
-  }
-
-  .step-number {
-    margin-top: 0;
-  }
-
-  .case-meta {
-    grid-template-columns: 1fr;
-  }
-}
-
-.repo-live-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.45rem;
-  margin-top: var(--space-2);
-  color: #c6e6ff;
-  font-weight: 700;
-  text-decoration: none;
-}
-
+.project-category + .project-category { margin-top: var(--space-6); }
+.project-category > h3 { margin-bottom: var(--space-3); }
+.project-tag { margin-bottom: var(--space-1); color: var(--accent); font-weight: 700; font-size: 0.75rem; letter-spacing: 0.09em; text-transform: uppercase; }
+.repo-description { min-height: 3.2rem; }
+.project-answers { display: grid; grid-template-columns: 8rem 1fr; gap: 0.45rem 0.9rem; margin: var(--space-2) 0; }
+.project-answers dt { color: var(--text-primary); font-weight: 700; }
+.project-answers dd { margin: 0; color: var(--text-muted); }
+.tech-list { display: flex; flex-wrap: wrap; gap: 0.45rem; margin-bottom: var(--space-2); }
+.tech-list span { background: var(--accent-soft); color: var(--accent); padding: 0.3rem 0.6rem; font-size: 0.78rem; }
+.project-links { display: flex; flex-wrap: wrap; gap: 1rem; margin-top: auto; }
+.project-links a,
+.repo-live-link { color: var(--accent); font-weight: 700; text-decoration: none; }
+.project-links a:hover,
+.project-links a:focus,
 .repo-live-link:hover,
-.repo-live-link:focus {
-  color: #ffffff;
-  text-decoration: underline;
-  text-underline-offset: 0.22em;
-}
-
-.feature-actions {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  min-width: 190px;
-}
-
-.repo-board-page {
-  background:
-    radial-gradient(circle at 18% 18%, rgba(62, 166, 255, 0.18), transparent 32rem),
-    radial-gradient(circle at 90% 10%, rgba(112, 220, 255, 0.12), transparent 28rem),
-    linear-gradient(180deg, #070d18 0%, #0b1220 48%, #06101d 100%);
-}
-
-.repo-hero {
-  padding: calc(var(--space-8) + var(--space-2)) 0 var(--space-5);
-}
-
-.repo-shell,
-.repo-panel,
-.repo-status-card {
-  border: 1px solid rgba(148, 190, 230, 0.22);
-  background: rgba(9, 16, 29, 0.86);
-  box-shadow: 0 24px 60px rgba(1, 8, 18, 0.38);
-}
-
-.repo-shell {
-  overflow: hidden;
-  border-radius: 1.25rem;
-}
-
-.repo-titlebar {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  padding: 0.85rem 1rem;
-  border-bottom: 1px solid rgba(148, 190, 230, 0.2);
-  background: linear-gradient(90deg, rgba(17, 31, 56, 0.96), rgba(10, 19, 34, 0.96));
-}
-
-.repo-window-controls {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.42rem;
-}
-
-.repo-window-controls span {
-  width: 0.72rem;
-  height: 0.72rem;
-  border-radius: 50%;
-  background: #ff6b6b;
-}
-
-.repo-window-controls span:nth-child(2) {
-  background: #ffd166;
-}
-
-.repo-window-controls span:nth-child(3) {
-  background: #5ee6a8;
-}
-
-.repo-path,
-.repo-sync-pill {
-  margin: 0;
-  color: #cfe9ff;
-}
-
-.repo-path {
-  flex: 1;
-  font-family: var(--bs-font-monospace, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
-  font-size: 0.95rem;
-}
-
-.repo-sync-pill,
-.repo-chip,
-.pr-state {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.42rem;
-  border-radius: 999px;
-  border: 1px solid rgba(126, 189, 255, 0.42);
-  background: rgba(62, 166, 255, 0.13);
-  color: #cfebff;
-  padding: 0.35rem 0.7rem;
-  font-size: 0.78rem;
-  font-weight: 800;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-}
-
-.repo-hero-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(290px, 0.7fr);
-  gap: var(--space-4);
-  padding: var(--space-5);
-}
-
-.repo-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  margin-top: var(--space-3);
-}
-
-.repo-status-card {
-  position: relative;
-  overflow: hidden;
-  border-radius: 1rem;
-  padding: var(--space-3);
-}
-
-.repo-status-card::before {
-  content: "";
-  position: absolute;
-  inset: -40% -25% auto auto;
-  width: 16rem;
-  height: 16rem;
-  border-radius: 50%;
-  background: rgba(62, 166, 255, 0.18);
-  filter: blur(10px);
-}
-
-.status-orb {
-  position: relative;
-  width: 3.2rem;
-  height: 3.2rem;
-  border-radius: 50%;
-  margin-bottom: var(--space-2);
-  background: radial-gradient(circle, #9be7ff 0%, #3ea6ff 42%, rgba(62, 166, 255, 0.08) 72%);
-  box-shadow: 0 0 0 0 rgba(62, 166, 255, 0.45);
-  animation: pulse-orb 2.2s infinite;
-}
-
-@keyframes pulse-orb {
-  0% { box-shadow: 0 0 0 0 rgba(62, 166, 255, 0.38); }
-  70% { box-shadow: 0 0 0 1.1rem rgba(62, 166, 255, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(62, 166, 255, 0); }
-}
-
-.repo-mini-stats {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: var(--space-2);
-  margin: var(--space-3) 0 0;
-}
-
-.repo-mini-stats div,
-.repo-stat-card {
-  border: 1px solid rgba(255, 255, 255, 0.11);
-  border-radius: 0.85rem;
-  background: rgba(17, 31, 56, 0.72);
-  padding: 0.8rem;
-}
-
-.repo-mini-stats dt,
-.repo-stat-label {
-  color: var(--text-muted);
-  font-size: 0.74rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-weight: 700;
-}
-
-.repo-mini-stats dd {
-  margin: 0.25rem 0 0;
-  color: var(--text-primary);
-  font-weight: 800;
-}
-
-.repo-dashboard-section {
-  padding-top: var(--space-6);
-}
-
-.repo-dashboard-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.45fr) minmax(280px, 0.75fr);
-  gap: var(--space-4);
-}
-
-.repo-panel {
-  position: relative;
-  z-index: 1;
-  border-radius: 1rem;
-  padding: var(--space-3);
-}
-
-.repo-panel-header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--space-3);
-  margin-bottom: var(--space-3);
-}
-
-.repo-panel-header.compact {
-  margin-bottom: var(--space-2);
-}
-
-.repo-stat-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: var(--space-2);
-  margin: var(--space-3) 0;
-}
-
-.repo-stat-value {
-  display: block;
-  color: #ffffff;
-  font-size: clamp(1.35rem, 2.6vw, 2rem);
-  font-weight: 800;
-  letter-spacing: -0.03em;
-}
-
-.repo-stat-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-}
-
-.repo-terminal {
-  border: 1px solid rgba(94, 230, 168, 0.24);
-  border-radius: 0.95rem;
-  background: #050b12;
-  color: #9ef2c3;
-  font-family: var(--bs-font-monospace, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
-  padding: 1rem;
-}
-
-.repo-terminal p {
-  margin: 0;
-  color: #9ef2c3;
-  font-size: 0.88rem;
-}
-
-.repo-terminal p + p {
-  margin-top: 0.45rem;
-}
-
-.repo-terminal span {
-  color: #55b8ff;
-}
-
-.repo-proof-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
-  display: grid;
-  gap: var(--space-2);
-}
-
-.repo-proof-list li {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.7rem;
-  color: #dceeff;
-}
-
-.repo-proof-list i {
-  color: var(--accent);
-  margin-top: 0.15rem;
-}
-
-.repo-feed,
-.commit-stream {
-  display: grid;
-  gap: var(--space-2);
-}
-
-.repo-feed-item,
-.commit-item {
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 0.9rem;
-  background: rgba(17, 31, 56, 0.68);
-  padding: var(--space-2);
-}
-
-.repo-feed-item h3 {
-  font-size: 1.04rem;
-  margin: 0.7rem 0 0.55rem;
-}
-
-.repo-feed-item h3 a,
-.commit-item {
-  color: #f1f8ff;
-  text-decoration: none;
-}
-
-.repo-feed-item h3 a:hover,
-.commit-item:hover strong {
-  color: #8fd0ff;
-  text-decoration: underline;
-  text-underline-offset: 0.2em;
-}
-
-.repo-feed-item p {
-  color: var(--text-muted);
-  margin-bottom: 0.75rem;
-}
-
-.feed-item-topline {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--space-2);
-  color: var(--text-muted);
-  font-size: 0.86rem;
-}
-
-.pr-state-merged {
-  border-color: rgba(161, 125, 255, 0.46);
-  background: rgba(126, 87, 255, 0.17);
-  color: #dacbff;
-}
-
-.pr-state-open {
-  border-color: rgba(94, 230, 168, 0.42);
-  background: rgba(94, 230, 168, 0.13);
-  color: #baf7d4;
-}
-
-.pr-state-closed,
-.pr-state-sync-note {
-  border-color: rgba(255, 209, 102, 0.42);
-  background: rgba(255, 209, 102, 0.13);
-  color: #ffe2a3;
-}
-
-.feed-author {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  color: #c8e4ff;
-  font-size: 0.86rem;
-  font-weight: 650;
-}
-
-.repo-refresh-btn {
-  border: 1px solid rgba(126, 189, 255, 0.45);
-  border-radius: 999px;
-  background: rgba(62, 166, 255, 0.12);
-  color: #d8efff;
-  font-weight: 800;
-  padding: 0.45rem 0.78rem;
-}
-
-.repo-refresh-btn:hover,
-.repo-refresh-btn:focus {
-  border-color: #9ed0ff;
-  background: rgba(62, 166, 255, 0.2);
-}
-
-.repo-refresh-btn.is-loading i {
-  animation: spin 1s linear infinite;
-}
-
-@keyframes spin {
-  to { transform: rotate(360deg); }
-}
-
-.commit-item {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 0.75rem;
-  align-items: start;
-}
-
-.commit-node {
-  width: 0.8rem;
-  height: 0.8rem;
-  border-radius: 50%;
-  background: #5ee6a8;
-  box-shadow: 0 0 0 0.35rem rgba(94, 230, 168, 0.1);
-  margin-top: 0.36rem;
-}
-
-.commit-copy strong,
-.commit-copy small {
-  display: block;
-}
-
-.commit-copy small {
-  color: var(--text-muted);
-  margin-top: 0.35rem;
-}
-
-.skeleton-card span {
-  display: block;
-  height: 0.8rem;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0.08));
-  background-size: 200% 100%;
-  animation: shimmer 1.4s ease-in-out infinite;
-}
-
-.skeleton-card span + span {
-  margin-top: 0.7rem;
-  width: 75%;
-}
-
-.skeleton-card span:nth-child(3) {
-  width: 48%;
-}
-
-@keyframes shimmer {
-  to { background-position: -200% 0; }
-}
-
-@media (max-width: 991px) {
-  .repo-hero-grid,
-  .repo-dashboard-grid {
-    grid-template-columns: 1fr;
-  }
-
-  .repo-titlebar,
-  .repo-panel-header {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .repo-stat-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
+.repo-live-link:focus { color: #173953; text-decoration: underline; text-underline-offset: 0.22em; }
+
+.site-footer { padding: var(--space-7) 0; background: #111827; color: #f7fafc; }
+.site-footer .cta-secondary { color: #e8f2ff; border-color: rgba(255, 255, 255, 0.28); }
+.site-footer .cta-tertiary,
+.contact-list a { color: #d7e8ff; }
+.contact-list { list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: var(--space-2) var(--space-4); }
+.contact-list a { text-decoration: none; }
+.contact-list a:hover,
+.contact-list a:focus { color: #fff; text-decoration: underline; }
+.copyright { margin-top: var(--space-3); font-size: 0.9rem; }
+
+@media (max-width: 991px) { .hero-section { padding-top: calc(var(--space-8) + var(--space-1)); } }
 @media (max-width: 767px) {
-  .repo-hero {
-    padding-top: var(--space-6);
-  }
-
-  .repo-hero-grid,
-  .repo-shell .repo-titlebar {
-    padding: var(--space-3);
-  }
-
-  .repo-actions .btn,
-  .feature-actions .btn {
-    width: 100%;
-  }
-
-  .repo-mini-stats,
-  .repo-stat-grid {
-    grid-template-columns: 1fr;
-  }
-}
-
-.tracepoint-nav-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2);
-  justify-content: flex-end;
-}
-
-@media (max-width: 767px) {
-  .tracepoint-nav-actions {
-    width: 100%;
-    margin-top: var(--space-2);
-  }
-
-  .tracepoint-nav-actions .btn {
-    flex: 1 1 100%;
-  }
+  .content-section { padding: var(--space-6) 0; }
+  .cta-group .cta-btn,
+  .cta-group .cta-tertiary { width: 100%; text-align: center; }
+  .project-answers { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
### Motivation
- Present a clearer professional identity up front so visitors immediately understand who the owner is and what they build.  
- Reuse the existing Bootstrap-based structure and assets while reorganizing content to emphasize process-driven engineering, workflow automation, and operational impact.  
- Make project presentation more structured and resilient by grouping projects and attempting to enrich cards with live GitHub metadata while preserving graceful fallbacks.

### Description
- Updated the homepage `index.html` to replace the original landing copy with a focused hero (`Software Engineer`) plus a concise professional summary, primary CTAs (`View Projects`, `GitHub`, `Contact / Resume`), a compact About section, grouped Skills, and a minimal "What I Enjoy Solving" area.  
- Reworked project presentation into a categorized catalog (`Selected Engineering Projects`) and added a placeholder container populated by client-side rendering; kept project text factual (TracePoint, GRAND, TraceSync, Excel Companion, Accounting-related items).  
- Replaced the previous dark design with a lighter, professional CSS theme in `portfolio-refresh.css`, preserving Bootstrap compatibility and responsive behavior while simplifying and consolidating styles.  
- Rewrote `js/portfolio-refresh.js` to centralize small UI behaviors (footer year and nav collapse) and to attempt loading repository metadata from the GitHub API to render project cards, with robust normalization and a graceful fallback when metadata is unavailable.  
- Updated `README.md` to describe the redesigned site structure, files changed, and the GitHub-metadata rendering approach; retained compatibility with static GitHub Pages deployment.

### Testing
- Ran a static HTML parse of `index.html` using Python's `html.parser`, which completed successfully.  
- Performed local file presence/size checks for `portfolio-refresh.css`, `js/portfolio-refresh.js`, and `README.md`, which reported expected files and nonzero sizes.  
- Started a local static server with `python -m http.server` to validate serving the page; the server started successfully but automated visual screenshot via a Node/Playwright script failed because `playwright` is not installed in the environment.  
- Verified that client-side GitHub API failures are handled by the script (`fetch(...).catch(() => renderProjects([]))`) so the page falls back to static project copy when API access is blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a704c6b576c8324930d4ff3738d4f5c)